### PR TITLE
feat: add API proxy, httpOnly JWT cookies, and typed gateway client -…

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -43,6 +43,17 @@ Use semantic tokens in Tailwind via arbitrary values: `bg-[--color-danger]`, `te
 - **JetBrains Mono** — display headings + monospaced data (`var(--font-display)` / `var(--font-mono)`)
 - **Geist** — body copy (`var(--font-sans)`)
 
+## Why the proxy
+
+All API calls go through `app/api/proxy/[...path]/route.ts` instead of hitting the gateway directly from the browser. This eliminates XSS risk: JWTs live in `httpOnly` cookies that JavaScript cannot read, so a successful script injection cannot exfiltrate credentials. The proxy also handles silent token refresh — when a request returns 401, it retries once with a fresh access token before giving up, keeping sessions alive without any client-side token management.
+
+Cookies used:
+
+| Cookie | `SameSite` | `Secure` | TTL |
+|---|---|---|---|
+| `fm_access` | `Lax` | prod only | 15 min |
+| `fm_refresh` | `Strict` | always | 30 days |
+
 ## Dev routes
 
 - `/_kitchen` — design system kitchen sink (dev-only, filled in by DS1/DS2/DS3 issues)

--- a/apps/web/app/api/proxy/[...path]/route.ts
+++ b/apps/web/app/api/proxy/[...path]/route.ts
@@ -1,0 +1,135 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+const GATEWAY_URL = process.env.GATEWAY_URL ?? "http://localhost";
+const ACCESS_COOKIE = "fm_access";
+const REFRESH_COOKIE = "fm_refresh";
+const ACCESS_MAX_AGE = 15 * 60;
+const REFRESH_MAX_AGE = 30 * 24 * 60 * 60;
+
+type RouteContext = { params: Promise<{ path: string[] }> };
+
+function accessOpts(secure: boolean) {
+  return {
+    httpOnly: true,
+    secure,
+    sameSite: "lax" as const,
+    maxAge: ACCESS_MAX_AGE,
+    path: "/",
+  };
+}
+
+function refreshOpts() {
+  return {
+    httpOnly: true,
+    secure: true,
+    sameSite: "strict" as const,
+    maxAge: REFRESH_MAX_AGE,
+    path: "/",
+  };
+}
+
+const isProd = () => process.env.NODE_ENV === "production";
+
+async function attemptRefresh(
+  cookieStore: Awaited<ReturnType<typeof cookies>>
+): Promise<string | null> {
+  const refreshToken = cookieStore.get(REFRESH_COOKIE)?.value;
+  if (!refreshToken) return null;
+
+  const res = await fetch(`${GATEWAY_URL}/api/users/refresh`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ refreshToken }),
+  });
+
+  if (!res.ok) return null;
+
+  const data = (await res.json()) as { accessToken: string; refreshToken?: string };
+  cookieStore.set(ACCESS_COOKIE, data.accessToken, accessOpts(isProd()));
+  if (data.refreshToken) {
+    cookieStore.set(REFRESH_COOKIE, data.refreshToken, refreshOpts());
+  }
+
+  return data.accessToken;
+}
+
+async function proxyRequest(req: NextRequest, ctx: RouteContext): Promise<NextResponse> {
+  const { path } = await ctx.params;
+  const cookieStore = await cookies();
+  const pathStr = path.join("/");
+  const search = req.nextUrl.search;
+  const upstreamUrl = `${GATEWAY_URL}/${pathStr}${search}`;
+
+  const isLogin = pathStr === "api/users/login";
+  const isLogout = pathStr === "api/users/logout";
+
+  const headers = new Headers({ "Content-Type": "application/json", Accept: "application/json" });
+  const accessToken = cookieStore.get(ACCESS_COOKIE)?.value;
+  if (accessToken) {
+    headers.set("Authorization", `Bearer ${accessToken}`);
+  }
+
+  const body =
+    req.method !== "GET" && req.method !== "HEAD" ? await req.text() : undefined;
+
+  const callUpstream = () =>
+    fetch(upstreamUrl, { method: req.method, headers, body });
+
+  let upstream = await callUpstream();
+
+  if (upstream.status === 401 && !isLogin) {
+    const newToken = await attemptRefresh(cookieStore);
+    if (newToken) {
+      headers.set("Authorization", `Bearer ${newToken}`);
+      upstream = await callUpstream();
+    }
+    if (upstream.status === 401) {
+      cookieStore.delete(ACCESS_COOKIE);
+      cookieStore.delete(REFRESH_COOKIE);
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  if (isLogin && upstream.ok) {
+    const data = (await upstream.json()) as {
+      accessToken: string;
+      refreshToken: string;
+      user: unknown;
+    };
+    const response = NextResponse.json({ user: data.user }, { status: upstream.status });
+    response.cookies.set(ACCESS_COOKIE, data.accessToken, accessOpts(isProd()));
+    response.cookies.set(REFRESH_COOKIE, data.refreshToken, refreshOpts());
+    return response;
+  }
+
+  if (isLogout && upstream.ok) {
+    const response = NextResponse.json({}, { status: 200 });
+    response.cookies.delete(ACCESS_COOKIE);
+    response.cookies.delete(REFRESH_COOKIE);
+    return response;
+  }
+
+  const responseBody = await upstream.text();
+  const contentType = upstream.headers.get("Content-Type") ?? "application/json";
+  return new NextResponse(responseBody || null, {
+    status: upstream.status,
+    headers: { "Content-Type": contentType },
+  });
+}
+
+export async function GET(req: NextRequest, ctx: RouteContext) {
+  return proxyRequest(req, ctx);
+}
+export async function POST(req: NextRequest, ctx: RouteContext) {
+  return proxyRequest(req, ctx);
+}
+export async function PATCH(req: NextRequest, ctx: RouteContext) {
+  return proxyRequest(req, ctx);
+}
+export async function PUT(req: NextRequest, ctx: RouteContext) {
+  return proxyRequest(req, ctx);
+}
+export async function DELETE(req: NextRequest, ctx: RouteContext) {
+  return proxyRequest(req, ctx);
+}

--- a/apps/web/lib/api/bids.ts
+++ b/apps/web/lib/api/bids.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import { apiFetch } from "./client";
+
+const BidStatusSchema = z.enum(["Pending", "Accepted", "Rejected"]);
+
+const BidSchema = z.object({
+  _id: z.string(),
+  loadId: z.string(),
+  carrierId: z.string().optional(),
+  priceUSD: z.number(),
+  estimatedDeliveryHours: z.number(),
+  status: BidStatusSchema,
+});
+
+export type Bid = z.infer<typeof BidSchema>;
+export type BidStatus = z.infer<typeof BidStatusSchema>;
+
+export type CreateBidInput = {
+  loadId: string;
+  priceUSD: number;
+  estimatedDeliveryHours: number;
+};
+
+export async function create(input: CreateBidInput): Promise<Bid> {
+  const data = await apiFetch<unknown>("api/bids", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+  return BidSchema.parse(data);
+}
+
+export async function listMine(): Promise<Bid[]> {
+  const data = await apiFetch<unknown>("api/bids/my");
+  return z.array(BidSchema).parse(data);
+}
+
+export async function listForLoad(loadId: string): Promise<Bid[]> {
+  const data = await apiFetch<unknown>(`api/bids/${loadId}`);
+  return z.array(BidSchema).parse(data);
+}
+
+export async function accept(bidId: string): Promise<Bid> {
+  const data = await apiFetch<unknown>(`api/bids/${bidId}/accept`, {
+    method: "PATCH",
+  });
+  return BidSchema.parse(data);
+}

--- a/apps/web/lib/api/chat.ts
+++ b/apps/web/lib/api/chat.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import { apiFetch } from "./client";
+
+const ChatMessageSchema = z.object({
+  _id: z.string(),
+  loadId: z.string(),
+  senderId: z.string(),
+  content: z.string(),
+  createdAt: z.string(),
+});
+
+export type ChatMessage = z.infer<typeof ChatMessageSchema>;
+
+export type SendMessageInput = {
+  loadId: string;
+  content: string;
+};
+
+export async function sendMessage(input: SendMessageInput): Promise<ChatMessage> {
+  const data = await apiFetch<unknown>("api/chat/messages", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+  return ChatMessageSchema.parse(data);
+}

--- a/apps/web/lib/api/client.ts
+++ b/apps/web/lib/api/client.ts
@@ -1,0 +1,35 @@
+export class ApiResponseError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string
+  ) {
+    super(message);
+    this.name = "ApiResponseError";
+  }
+}
+
+export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`/api/proxy/${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...init?.headers,
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    let message = text;
+    try {
+      const json = JSON.parse(text) as { error?: string; message?: string };
+      message = json.error ?? json.message ?? text;
+    } catch {
+      // use raw text
+    }
+    throw new ApiResponseError(res.status, message);
+  }
+
+  if (res.status === 204) return undefined as T;
+
+  return res.json() as Promise<T>;
+}

--- a/apps/web/lib/api/loads.ts
+++ b/apps/web/lib/api/loads.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+import { apiFetch } from "./client";
+
+const LoadStatusSchema = z.enum(["Draft", "Posted", "Matched", "InTransit", "Delivered"]);
+
+const LoadSchema = z.object({
+  _id: z.string(),
+  shipperId: z.string().optional(),
+  title: z.string(),
+  origin: z.string(),
+  destination: z.string(),
+  cargoType: z.string(),
+  weightKg: z.number(),
+  deadlineHours: z.number(),
+  status: LoadStatusSchema,
+  statusHistory: z
+    .array(
+      z.object({
+        from: z.string().nullable(),
+        to: z.string(),
+      })
+    )
+    .optional(),
+});
+
+export type Load = z.infer<typeof LoadSchema>;
+export type LoadStatus = z.infer<typeof LoadStatusSchema>;
+
+export type CreateLoadInput = {
+  title: string;
+  origin: string;
+  destination: string;
+  cargoType: string;
+  weightKg: number;
+  deadlineHours: number;
+};
+
+export type UpdateLoadInput = Partial<Omit<CreateLoadInput, "origin" | "destination">> & {
+  origin?: string;
+  destination?: string;
+};
+
+export type ListAvailableParams = {
+  origin?: string;
+  destination?: string;
+  cargoType?: string;
+};
+
+export async function createLoad(input: CreateLoadInput): Promise<Load> {
+  const data = await apiFetch<unknown>("api/loads", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+  return LoadSchema.parse(data);
+}
+
+export async function list(): Promise<Load[]> {
+  const data = await apiFetch<unknown>("api/loads/my-loads");
+  return z.array(LoadSchema).parse(data);
+}
+
+export async function listAvailable(params?: ListAvailableParams): Promise<Load[]> {
+  const query = new URLSearchParams();
+  if (params?.origin) query.set("origin", params.origin);
+  if (params?.destination) query.set("destination", params.destination);
+  if (params?.cargoType) query.set("cargoType", params.cargoType);
+  const qs = query.size > 0 ? `?${query.toString()}` : "";
+  const data = await apiFetch<unknown>(`api/loads/available${qs}`);
+  return z.array(LoadSchema).parse(data);
+}
+
+export async function get(id: string): Promise<Load> {
+  const data = await apiFetch<unknown>(`api/loads/${id}`);
+  return LoadSchema.parse(data);
+}
+
+export async function updateStatus(id: string, status: LoadStatus): Promise<Load> {
+  const data = await apiFetch<unknown>(`api/loads/${id}/status`, {
+    method: "PATCH",
+    body: JSON.stringify({ status }),
+  });
+  return LoadSchema.parse(data);
+}
+
+export async function update(id: string, input: UpdateLoadInput): Promise<Load> {
+  const data = await apiFetch<unknown>(`api/loads/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(input),
+  });
+  return LoadSchema.parse(data);
+}

--- a/apps/web/lib/api/match.ts
+++ b/apps/web/lib/api/match.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { apiFetch } from "./client";
+
+const RecommendationSchema = z.object({
+  carrierId: z.string(),
+  score: z.number(),
+  reason: z.string(),
+});
+
+const RecommendationResultSchema = z.object({
+  _id: z.string(),
+  loadId: z.string(),
+  recommendations: z.array(RecommendationSchema),
+});
+
+export type Recommendation = z.infer<typeof RecommendationSchema>;
+export type RecommendationResult = z.infer<typeof RecommendationResultSchema>;
+
+export type TriggerRecommendationInput = {
+  loadId: string;
+  origin: string;
+  destination: string;
+  cargoType: string;
+  weightKg: number;
+  deadlineHours: number;
+  shipperId: string;
+};
+
+export async function getRecommendations(loadId: string): Promise<RecommendationResult> {
+  const data = await apiFetch<unknown>(`api/match/${loadId}`);
+  return RecommendationResultSchema.parse(data);
+}
+
+export async function triggerRecommendation(
+  input: TriggerRecommendationInput
+): Promise<RecommendationResult> {
+  const data = await apiFetch<unknown>("api/match/recommend", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+  return RecommendationResultSchema.parse(data);
+}

--- a/apps/web/lib/api/users.ts
+++ b/apps/web/lib/api/users.ts
@@ -1,0 +1,100 @@
+import { z } from "zod";
+import { apiFetch } from "./client";
+
+const UserSchema = z.object({
+  id: z.string().optional(),
+  _id: z.string().optional(),
+  email: z.string().email(),
+  role: z.enum(["Shipper", "Carrier"]),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+});
+
+const CarrierProfileSchema = z.object({
+  truckType: z.enum(["flatbed", "refrigerated", "dry-van", "tanker"]),
+  capacityKg: z.number(),
+  homeCity: z.string(),
+  rating: z.number().optional(),
+  completedShipments: z.number().optional(),
+});
+
+const RegisterResponseSchema = z.object({
+  id: z.string(),
+  email: z.string(),
+  role: z.enum(["Shipper", "Carrier"]),
+  createdAt: z.string(),
+});
+
+const LoginResponseSchema = z.object({
+  user: UserSchema,
+});
+
+const ProfileResponseSchema = UserSchema.extend({
+  carrierProfile: CarrierProfileSchema.optional(),
+});
+
+const CarrierProfileResponseSchema = UserSchema.extend({
+  carrierProfile: CarrierProfileSchema,
+});
+
+export type User = z.infer<typeof UserSchema>;
+export type CarrierProfile = z.infer<typeof CarrierProfileSchema>;
+export type RegisterResponse = z.infer<typeof RegisterResponseSchema>;
+export type LoginResponse = z.infer<typeof LoginResponseSchema>;
+export type ProfileResponse = z.infer<typeof ProfileResponseSchema>;
+
+export type RegisterInput = {
+  email: string;
+  password: string;
+  role: "Shipper" | "Carrier";
+};
+
+export type LoginInput = {
+  email: string;
+  password: string;
+};
+
+export type UpdateCarrierProfileInput = {
+  truckType?: "flatbed" | "refrigerated" | "dry-van" | "tanker";
+  capacityKg?: number;
+  homeCity?: string;
+};
+
+export async function register(input: RegisterInput): Promise<RegisterResponse> {
+  const data = await apiFetch<unknown>("api/users/register", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+  return RegisterResponseSchema.parse(data);
+}
+
+export async function login(input: LoginInput): Promise<LoginResponse> {
+  const data = await apiFetch<unknown>("api/users/login", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+  return LoginResponseSchema.parse(data);
+}
+
+export async function logout(): Promise<void> {
+  await apiFetch<void>("api/users/logout", { method: "POST" });
+}
+
+export async function refresh(): Promise<void> {
+  await apiFetch<void>("api/users/refresh", { method: "POST" });
+}
+
+export async function getProfile(): Promise<ProfileResponse> {
+  const data = await apiFetch<unknown>("api/users/profile");
+  return ProfileResponseSchema.parse(data);
+}
+
+export async function updateCarrierProfile(
+  input: UpdateCarrierProfileInput
+): Promise<z.infer<typeof CarrierProfileResponseSchema>> {
+  const data = await apiFetch<unknown>("api/users/carrier-profile", {
+    method: "PATCH",
+    body: JSON.stringify(input),
+  });
+  return CarrierProfileResponseSchema.parse(data);
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "next": "^15.3.1",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.5(react@19.2.5)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.1.4
@@ -3867,6 +3870,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -7823,3 +7829,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.25.76: {}
+
+  zod@4.3.6: {}


### PR DESCRIPTION
… closes #41

- app/api/proxy/[...path]/route.ts: catch-all proxy to GATEWAY_URL; injects fm_access Bearer header, handles login/logout cookie lifecycle, silent refresh on 401
- lib/api/client.ts: apiFetch<T> typed fetch wrapper that always routes through proxy
- lib/api/{users,loads,bids,match,chat}.ts: fully typed API modules with Zod response schemas
- README: "Why the proxy" section explaining httpOnly cookie XSS rationale