### PR TITLE
feat: auth context, role-aware middleware, protected layout groups

### DIFF
--- a/apps/web/app/(auth)/layout.tsx
+++ b/apps/web/app/(auth)/layout.tsx
@@ -1,0 +1,27 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+function decodeRole(token: string): string | null {
+  try {
+    const payload = token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/");
+    const data = JSON.parse(Buffer.from(payload, "base64").toString("utf-8")) as {
+      role?: string;
+    };
+    return data.role ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function AuthLayout({ children }: { children: React.ReactNode }) {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("fm_access")?.value;
+
+  if (accessToken) {
+    const role = decodeRole(accessToken);
+    if (role === "Shipper") redirect("/shipper/dashboard");
+    if (role === "Carrier") redirect("/carrier/dashboard");
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -1,0 +1,13 @@
+export default function LoginPage() {
+  return (
+    <main className="flex min-h-dvh items-center justify-center px-6">
+      <div className="space-y-2 text-center">
+        <p className="font-mono text-xs tracking-widest text-amber-400 uppercase">FreightMatch</p>
+        <h1 className="text-2xl font-bold text-slate-100" style={{ fontFamily: "var(--font-display)" }}>
+          Sign in
+        </h1>
+        <p className="text-sm text-slate-500">Login form — coming in SH1 / CA1</p>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -1,0 +1,13 @@
+export default function RegisterPage() {
+  return (
+    <main className="flex min-h-dvh items-center justify-center px-6">
+      <div className="space-y-2 text-center">
+        <p className="font-mono text-xs tracking-widest text-amber-400 uppercase">FreightMatch</p>
+        <h1 className="text-2xl font-bold text-slate-100" style={{ fontFamily: "var(--font-display)" }}>
+          Create account
+        </h1>
+        <p className="text-sm text-slate-500">Register form — coming in SH1 / CA1</p>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/(carrier)/carrier/dashboard/page.tsx
+++ b/apps/web/app/(carrier)/carrier/dashboard/page.tsx
@@ -1,0 +1,11 @@
+export default function CarrierDashboardPage() {
+  return (
+    <div className="px-8 py-12">
+      <p className="font-mono text-xs text-amber-400 uppercase tracking-widest">Carrier</p>
+      <h1 className="mt-1 text-2xl font-bold text-slate-100" style={{ fontFamily: "var(--font-display)" }}>
+        Dashboard
+      </h1>
+      <p className="mt-3 text-sm text-slate-500">Carrier dashboard — coming in CA2</p>
+    </div>
+  );
+}

--- a/apps/web/app/(carrier)/layout.tsx
+++ b/apps/web/app/(carrier)/layout.tsx
@@ -1,0 +1,10 @@
+import { Navbar } from "@/components/Navbar";
+
+export default function CarrierLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-dvh flex flex-col">
+      <Navbar />
+      <main className="flex-1">{children}</main>
+    </div>
+  );
+}

--- a/apps/web/app/(carrier)/marketplace/page.tsx
+++ b/apps/web/app/(carrier)/marketplace/page.tsx
@@ -1,0 +1,11 @@
+export default function MarketplacePage() {
+  return (
+    <div className="px-8 py-12">
+      <p className="font-mono text-xs text-amber-400 uppercase tracking-widest">Carrier</p>
+      <h1 className="mt-1 text-2xl font-bold text-slate-100" style={{ fontFamily: "var(--font-display)" }}>
+        Marketplace
+      </h1>
+      <p className="mt-3 text-sm text-slate-500">Available loads — coming in CA3</p>
+    </div>
+  );
+}

--- a/apps/web/app/(shipper)/layout.tsx
+++ b/apps/web/app/(shipper)/layout.tsx
@@ -1,0 +1,10 @@
+import { Navbar } from "@/components/Navbar";
+
+export default function ShipperLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-dvh flex flex-col">
+      <Navbar />
+      <main className="flex-1">{children}</main>
+    </div>
+  );
+}

--- a/apps/web/app/(shipper)/shipper/dashboard/page.tsx
+++ b/apps/web/app/(shipper)/shipper/dashboard/page.tsx
@@ -1,0 +1,11 @@
+export default function ShipperDashboardPage() {
+  return (
+    <div className="px-8 py-12">
+      <p className="font-mono text-xs text-amber-400 uppercase tracking-widest">Shipper</p>
+      <h1 className="mt-1 text-2xl font-bold text-slate-100" style={{ fontFamily: "var(--font-display)" }}>
+        Dashboard
+      </h1>
+      <p className="mt-3 text-sm text-slate-500">Shipper dashboard — coming in SH2</p>
+    </div>
+  );
+}

--- a/apps/web/app/403/page.tsx
+++ b/apps/web/app/403/page.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+export default function ForbiddenPage() {
+  return (
+    <main className="flex min-h-dvh flex-col items-center justify-center px-6 text-center">
+      <p className="font-mono text-xs tracking-widest text-[--color-danger] uppercase">
+        Access Denied
+      </p>
+      <h1
+        className="mt-2 text-5xl font-bold text-slate-100 tracking-tight"
+        style={{ fontFamily: "var(--font-display)" }}
+      >
+        403
+      </h1>
+      <p className="mt-3 text-sm text-slate-400 max-w-xs">
+        Your role does not have permission to access this page.
+      </p>
+      <Link
+        href="/"
+        className="mt-8 font-mono text-xs text-amber-400 hover:text-amber-300 underline underline-offset-4"
+      >
+        ← Return home
+      </Link>
+    </main>
+  );
+}

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -1,0 +1,27 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+function decodeRole(token: string): string | null {
+  try {
+    const payload = token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/");
+    const data = JSON.parse(Buffer.from(payload, "base64").toString("utf-8")) as {
+      role?: string;
+    };
+    return data.role ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function DashboardPage() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("fm_access")?.value;
+
+  if (!token) redirect("/login?next=/dashboard");
+
+  const role = decodeRole(token);
+  if (role === "Shipper") redirect("/shipper/dashboard");
+  if (role === "Carrier") redirect("/carrier/dashboard");
+
+  redirect("/login?next=/dashboard");
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist } from "next/font/google";
 import { JetBrains_Mono } from "next/font/google";
 import { GridBackdrop } from "@/components/GridBackdrop";
+import { Providers } from "./providers";
 import "./globals.css";
 
 const geist = Geist({
@@ -29,7 +30,7 @@ export default function RootLayout({
     <html lang="en" className={`${geist.variable} ${jetbrainsMono.variable}`}>
       <body className="antialiased">
         <GridBackdrop />
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { createContext, useContext, useState, useCallback, useEffect } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import type { User } from "@/lib/api/users";
+import { logout as apiLogout, getProfile } from "@/lib/api/users";
+
+type AuthContextValue = {
+  user: User | null;
+  setUser: (user: User | null) => void;
+  logout: () => Promise<void>;
+  isLoading: boolean;
+};
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used inside <Providers>");
+  return ctx;
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { staleTime: 60 * 1000 } },
+  });
+}
+
+let browserQueryClient: QueryClient | undefined;
+
+function getQueryClient() {
+  if (typeof window === "undefined") return makeQueryClient();
+  if (!browserQueryClient) browserQueryClient = makeQueryClient();
+  return browserQueryClient;
+}
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const queryClient = getQueryClient();
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    getProfile()
+      .then((p) => setUser(p))
+      .catch(() => setUser(null))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const logout = useCallback(async () => {
+    await apiLogout().catch(() => {});
+    queryClient.clear();
+    setUser(null);
+    router.push("/");
+  }, [queryClient, router]);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthContext.Provider value={{ user, setUser, isLoading, logout }}>
+        {children}
+      </AuthContext.Provider>
+    </QueryClientProvider>
+  );
+}

--- a/apps/web/components/Navbar.tsx
+++ b/apps/web/components/Navbar.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import Link from "next/link";
+import { useAuth } from "@/lib/hooks/useAuth";
+
+export function Navbar() {
+  const { user, logout } = useAuth();
+
+  return (
+    <header className="h-12 border-b border-slate-800 bg-slate-900/80 backdrop-blur-sm flex items-center px-6 gap-4">
+      <Link
+        href="/"
+        className="font-mono text-sm font-semibold text-slate-100 tracking-tight"
+        style={{ fontFamily: "var(--font-display)" }}
+      >
+        Freight<span className="text-amber-400">Match</span>
+      </Link>
+
+      <span className="flex-1" />
+
+      {user && (
+        <>
+          <span
+            className={[
+              "font-mono text-xs px-2 py-0.5 rounded border",
+              user.role === "Shipper"
+                ? "text-[--color-transit] border-[--color-transit]/30 bg-[--color-transit]/10"
+                : "text-[--color-go] border-[--color-go]/30 bg-[--color-go]/10",
+            ].join(" ")}
+          >
+            {user.role}
+          </span>
+
+          <div className="h-7 w-7 rounded-full bg-slate-700 border border-slate-600 flex items-center justify-center">
+            <span className="font-mono text-xs text-slate-300 uppercase">
+              {user.email.charAt(0)}
+            </span>
+          </div>
+
+          <button
+            onClick={() => void logout()}
+            className="font-mono text-xs text-slate-400 hover:text-slate-200 transition-colors"
+          >
+            logout
+          </button>
+        </>
+      )}
+    </header>
+  );
+}

--- a/apps/web/components/RequireRole.tsx
+++ b/apps/web/components/RequireRole.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useAuth } from "@/lib/hooks/useAuth";
+import type { User } from "@/lib/api/users";
+
+type Props = {
+  role: User["role"];
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+};
+
+export function RequireRole({ role, children, fallback = null }: Props) {
+  const { user } = useAuth();
+  if (user?.role !== role) return <>{fallback}</>;
+  return <>{children}</>;
+}

--- a/apps/web/lib/hooks/useAuth.ts
+++ b/apps/web/lib/hooks/useAuth.ts
@@ -1,0 +1,1 @@
+export { useAuth } from "@/app/providers";

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const PUBLIC_PATHS = ["/login", "/register", "/403", "/"];
+const SHIPPER_PATHS = ["/shipper"];
+const CARRIER_PATHS = ["/marketplace", "/carrier"];
+
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) return null;
+    const payload = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const decoded = Buffer.from(payload, "base64").toString("utf-8");
+    return JSON.parse(decoded) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  if (
+    pathname.startsWith("/_next") ||
+    pathname.startsWith("/api") ||
+    pathname.startsWith("/_kitchen") ||
+    PUBLIC_PATHS.some((p) => pathname === p)
+  ) {
+    return NextResponse.next();
+  }
+
+  const accessToken = req.cookies.get("fm_access")?.value;
+
+  if (!accessToken) {
+    const loginUrl = req.nextUrl.clone();
+    loginUrl.pathname = "/login";
+    loginUrl.searchParams.set("next", pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  const payload = decodeJwtPayload(accessToken);
+  const role = payload?.role as string | undefined;
+
+  const isShipperPath = SHIPPER_PATHS.some((p) => pathname.startsWith(p));
+  const isCarrierPath = CARRIER_PATHS.some((p) => pathname.startsWith(p));
+
+  if (isShipperPath && role !== "Shipper") {
+    return NextResponse.redirect(new URL("/403", req.url));
+  }
+
+  if (isCarrierPath && role !== "Carrier") {
+    return NextResponse.redirect(new URL("/403", req.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.99.2",
+    "jose": "^6.2.2",
     "next": "^15.3.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,12 @@ importers:
 
   apps/web:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.99.2
+        version: 5.99.2(react@19.2.5)
+      jose:
+        specifier: ^6.2.2
+        version: 6.2.2
       next:
         specifier: ^15.3.1
         version: 15.5.15(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1695,6 +1701,14 @@ packages:
   '@tailwindcss/postcss@4.2.4':
     resolution: {integrity: sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==}
 
+  '@tanstack/query-core@5.99.2':
+    resolution: {integrity: sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==}
+
+  '@tanstack/react-query@5.99.2':
+    resolution: {integrity: sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==}
+    peerDependencies:
+      react: ^18 || ^19
+
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
 
@@ -2921,6 +2935,9 @@ packages:
 
   joi@17.13.3:
     resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
+
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -5261,6 +5278,13 @@ snapshots:
       postcss: 8.5.10
       tailwindcss: 4.2.4
 
+  '@tanstack/query-core@5.99.2': {}
+
+  '@tanstack/react-query@5.99.2(react@19.2.5)':
+    dependencies:
+      '@tanstack/query-core': 5.99.2
+      react: 19.2.5
+
   '@tsconfig/node10@1.0.12': {}
 
   '@tsconfig/node12@1.0.11': {}
@@ -6733,6 +6757,8 @@ snapshots:
       '@sideway/address': 4.1.5
       '@sideway/formula': 3.0.1
       '@sideway/pinpoint': 2.0.0
+
+  jose@6.2.2: {}
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION
- middleware.ts: decodes fm_access JWT (no verify), redirects unauthed to /login?next=, wrong-role to /403
- (auth) layout: redirects already-authed users to their role dashboard
- (shipper)/(carrier) layouts: Navbar + role-guard via middleware
- Providers: TanStack Query client + AuthContext with user/logout
- useAuth hook + RequireRole component for inline guards
- Navbar: logo, role badge, avatar initial, logout
- /dashboard: server-side role redirect
- /403: ops-console styled forbidden page
- Stub pages for /login, /register, /shipper/dashboard, /carrier/dashboard, /marketplace
- Adds jose and @tanstack/react-query deps