### PR TITLE
[A1] Login + Register pages with role picker

### DIFF
--- a/apps/web/app/(auth)/_components/auth-shell.tsx
+++ b/apps/web/app/(auth)/_components/auth-shell.tsx
@@ -1,0 +1,77 @@
+import * as React from "react";
+import Link from "next/link";
+import { cn } from "@/lib/ui/cn";
+
+type AuthShellProps = {
+  children: React.ReactNode;
+  eyebrow: string;
+  heading: string;
+  subheading: string;
+  footerHref: string;
+  footerLabel: string;
+  footerText: string;
+};
+
+export function AuthShell({
+  children,
+  eyebrow,
+  heading,
+  subheading,
+  footerHref,
+  footerLabel,
+  footerText,
+}: AuthShellProps) {
+  return (
+    <main className="relative flex min-h-dvh items-center justify-center overflow-hidden px-4 py-10 sm:px-6">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none fixed inset-0 -z-10 opacity-[0.07] mix-blend-screen"
+        style={{
+          backgroundImage:
+            "radial-gradient(circle at 1px 1px, rgba(226,232,240,0.9) 1px, transparent 0)",
+          backgroundSize: "4px 4px",
+        }}
+      />
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-x-0 top-0 h-px bg-amber-400/30"
+      />
+      <section
+        className={cn(
+          "fm-panel-surface w-full max-w-[30rem] rounded-lg p-5 sm:p-6",
+          "after:pointer-events-none after:absolute after:inset-x-6 after:top-0 after:h-px after:bg-amber-400/40",
+        )}
+      >
+        <div className="relative space-y-6">
+          <header className="space-y-3">
+            <p className="font-mono text-[11px] font-semibold uppercase tracking-[0.28em] text-amber-400">
+              {eyebrow}
+            </p>
+            <div className="space-y-2">
+              <h1
+                className="text-2xl font-bold uppercase text-slate-100 sm:text-3xl"
+                style={{ fontFamily: "var(--font-display)" }}
+              >
+                FREIGHTMATCH // OPS
+              </h1>
+              <p className="text-sm leading-6 text-slate-400">{subheading}</p>
+            </div>
+            <h2 className="sr-only">{heading}</h2>
+          </header>
+
+          {children}
+
+          <p className="flex flex-col items-center gap-2 border-t border-slate-700/70 pt-4 text-center text-sm text-slate-500">
+            <span>{footerText}</span>
+            <Link
+              className="fm-focus-ring rounded-sm font-mono text-xs font-semibold uppercase tracking-[0.18em] text-amber-400 hover:text-amber-300"
+              href={footerHref}
+            >
+              {footerLabel}
+            </Link>
+          </p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/(auth)/_lib/redirects.ts
+++ b/apps/web/app/(auth)/_lib/redirects.ts
@@ -1,0 +1,21 @@
+import type { User } from "@/lib/api/users";
+
+const AUTH_PATHS = new Set(["/login", "/register"]);
+
+export function dashboardForRole(role: User["role"]) {
+  return role === "Shipper" ? "/shipper/dashboard" : "/carrier/dashboard";
+}
+
+export function safeNext(raw: string | null) {
+  if (!raw) return null;
+  if (!raw.startsWith("/") || raw.startsWith("//")) return null;
+
+  try {
+    const parsed = new URL(raw, "http://freightmatch.local");
+    if (parsed.origin !== "http://freightmatch.local") return null;
+    if (AUTH_PATHS.has(parsed.pathname)) return null;
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -1,16 +1,124 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { AuthShell } from "../_components/auth-shell";
+import { dashboardForRole, safeNext } from "../_lib/redirects";
+import { Button } from "@/components/primitives/button";
+import { Input } from "@/components/primitives/input";
+import { ApiResponseError } from "@/lib/api/client";
+import { login } from "@/lib/api/users";
+import { useAuth } from "@/lib/hooks/useAuth";
+
+const loginSchema = z.object({
+  email: z.string().trim().email("Enter a valid email address."),
+  password: z.string().min(1, "Password is required."),
+});
+
+type LoginFormValues = z.infer<typeof loginSchema>;
+
 export default function LoginPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { setUser } = useAuth();
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const {
+    formState: { errors, isSubmitting },
+    handleSubmit,
+    register,
+  } = useForm<LoginFormValues>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: { email: "", password: "" },
+  });
+
+  async function onSubmit(values: LoginFormValues) {
+    setFormError(null);
+
+    try {
+      const result = await login(values);
+      setUser(result.user);
+      const nextPath = safeNext(searchParams.get("next"));
+      router.replace(nextPath ?? dashboardForRole(result.user.role));
+      router.refresh();
+    } catch (error) {
+      if (error instanceof ApiResponseError && error.status === 401) {
+        setFormError("Invalid email or password.");
+        return;
+      }
+
+      setFormError(error instanceof Error ? error.message : "Unable to sign in right now.");
+    }
+  }
+
+  const formErrorId = formError ? "login-form-error" : undefined;
+
   return (
-    <main className="flex min-h-dvh items-center justify-center px-6">
-      <div className="space-y-2 text-center">
-        <p className="font-mono text-xs tracking-widest text-amber-400 uppercase">FreightMatch</p>
-        <h1
-          className="text-2xl font-bold text-slate-100"
-          style={{ fontFamily: "var(--font-display)" }}
-        >
+    <AuthShell
+      eyebrow="Secure console access"
+      footerHref="/register"
+      footerLabel="Create account"
+      footerText="New to FreightMatch?"
+      heading="Sign in"
+      subheading="Authenticate into the freight command surface with your shipper or carrier account."
+    >
+      <form
+        aria-describedby={formErrorId}
+        className="space-y-4"
+        noValidate
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        {formError ? (
+          <p
+            className="rounded-md border border-[color:var(--color-danger)]/45 bg-[color:var(--color-danger)]/10 px-3.5 py-3 font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-red-200"
+            id={formErrorId}
+            role="alert"
+          >
+            {formError}
+          </p>
+        ) : null}
+
+        <div className="space-y-2">
+          <label
+            className="font-mono text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-300"
+            htmlFor="login-email"
+          >
+            Email
+          </label>
+          <Input
+            autoComplete="username"
+            error={errors.email?.message}
+            id="login-email"
+            placeholder="dispatch@freightmatch.io"
+            type="email"
+            {...register("email")}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label
+            className="font-mono text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-300"
+            htmlFor="login-password"
+          >
+            Password
+          </label>
+          <Input
+            autoComplete="current-password"
+            error={errors.password?.message}
+            id="login-password"
+            placeholder="••••••••"
+            type="password"
+            {...register("password")}
+          />
+        </div>
+
+        <Button className="w-full" loading={isSubmitting} size="lg" type="submit">
           Sign in
-        </h1>
-        <p className="text-sm text-slate-500">Login form — coming in SH1 / CA1</p>
-      </div>
-    </main>
+        </Button>
+      </form>
+    </AuthShell>
   );
 }

--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -1,16 +1,252 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Building2, Truck } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { AuthShell } from "../_components/auth-shell";
+import { dashboardForRole } from "../_lib/redirects";
+import { Button } from "@/components/primitives/button";
+import { Input } from "@/components/primitives/input";
+import { cn } from "@/lib/ui/cn";
+import { login, register as registerUser } from "@/lib/api/users";
+import { useAuth } from "@/lib/hooks/useAuth";
+
+const passwordRules = [
+  { label: "8+ characters", test: (value: string) => value.length >= 8 },
+  { label: "Uppercase", test: (value: string) => /[A-Z]/.test(value) },
+  { label: "Lowercase", test: (value: string) => /[a-z]/.test(value) },
+  { label: "Number", test: (value: string) => /[0-9]/.test(value) },
+  {
+    label: "Special",
+    test: (value: string) => /[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]/.test(value),
+  },
+] as const;
+
+const registerSchema = z.object({
+  email: z.string().trim().email("Enter a valid email address."),
+  password: z
+    .string()
+    .min(8, "Use at least 8 characters.")
+    .regex(/[A-Z]/, "Include an uppercase letter.")
+    .regex(/[a-z]/, "Include a lowercase letter.")
+    .regex(/[0-9]/, "Include a number.")
+    .regex(/[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]/, "Include a special character."),
+  role: z.enum(["Shipper", "Carrier"], {
+    message: "Choose Shipper or Carrier.",
+  }),
+});
+
+type RegisterFormValues = z.infer<typeof registerSchema>;
+
+const roleOptions = [
+  {
+    description: "Post freight, compare bids, and coordinate your lanes.",
+    icon: Building2,
+    label: "Shipper",
+    value: "Shipper",
+  },
+  {
+    description: "Find posted loads, bid fast, and manage carrier ops.",
+    icon: Truck,
+    label: "Carrier",
+    value: "Carrier",
+  },
+] as const;
+
 export default function RegisterPage() {
+  const router = useRouter();
+  const { setUser } = useAuth();
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const {
+    formState: { errors, isSubmitting },
+    handleSubmit,
+    register,
+    watch,
+  } = useForm<RegisterFormValues>({
+    resolver: zodResolver(registerSchema),
+    defaultValues: { email: "", password: "", role: undefined },
+  });
+
+  const password = watch("password");
+  const selectedRole = watch("role");
+  const passedRules = passwordRules.filter((rule) => rule.test(password ?? "")).length;
+
+  async function onSubmit(values: RegisterFormValues) {
+    setFormError(null);
+
+    try {
+      await registerUser(values);
+      const result = await login({ email: values.email, password: values.password });
+      setUser(result.user);
+      router.replace(dashboardForRole(result.user.role));
+      router.refresh();
+    } catch (error) {
+      setFormError(
+        error instanceof Error ? error.message : "Unable to create the account right now.",
+      );
+    }
+  }
+
+  const formErrorId = formError ? "register-form-error" : undefined;
+  const roleErrorId = errors.role ? "register-role-error" : undefined;
+
   return (
-    <main className="flex min-h-dvh items-center justify-center px-6">
-      <div className="space-y-2 text-center">
-        <p className="font-mono text-xs tracking-widest text-amber-400 uppercase">FreightMatch</p>
-        <h1
-          className="text-2xl font-bold text-slate-100"
-          style={{ fontFamily: "var(--font-display)" }}
-        >
+    <AuthShell
+      eyebrow="Provision ops account"
+      footerHref="/login"
+      footerLabel="Sign in"
+      footerText="Already cleared for access?"
+      heading="Create account"
+      subheading="Create the account profile that determines which FreightMatch console you enter."
+    >
+      <form
+        aria-describedby={formErrorId}
+        className="space-y-5"
+        noValidate
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        {formError ? (
+          <p
+            className="rounded-md border border-[color:var(--color-danger)]/45 bg-[color:var(--color-danger)]/10 px-3.5 py-3 font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-red-200"
+            id={formErrorId}
+            role="alert"
+          >
+            {formError}
+          </p>
+        ) : null}
+
+        <div className="space-y-2">
+          <label
+            className="font-mono text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-300"
+            htmlFor="register-email"
+          >
+            Email
+          </label>
+          <Input
+            autoComplete="username"
+            error={errors.email?.message}
+            id="register-email"
+            placeholder="ops@freightmatch.io"
+            type="email"
+            {...register("email")}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label
+            className="font-mono text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-300"
+            htmlFor="register-password"
+          >
+            Password
+          </label>
+          <Input
+            autoComplete="new-password"
+            error={errors.password?.message}
+            id="register-password"
+            placeholder="Shipper123!"
+            type="password"
+            {...register("password")}
+          />
+          <div aria-hidden="true" className="grid grid-cols-5 gap-1">
+            {passwordRules.map((rule, index) => (
+              <span
+                className={cn(
+                  "h-1 rounded-full bg-slate-700",
+                  index < passedRules && "bg-amber-400",
+                )}
+                key={rule.label}
+              />
+            ))}
+          </div>
+          <ul className="flex flex-wrap gap-2" aria-label="Password requirements">
+            {passwordRules.map((rule) => {
+              const passed = rule.test(password ?? "");
+              return (
+                <li
+                  className={cn(
+                    "rounded border px-2 py-1 font-mono text-[10px] uppercase tracking-[0.16em]",
+                    passed
+                      ? "border-[color:var(--color-go)]/50 text-[var(--color-go)]"
+                      : "border-slate-700 text-slate-500",
+                  )}
+                  key={rule.label}
+                >
+                  {rule.label}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+
+        <fieldset aria-describedby={roleErrorId} className="space-y-3">
+          <legend className="font-mono text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-300">
+            Role
+          </legend>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {roleOptions.map((option) => {
+              const Icon = option.icon;
+              const checked = selectedRole === option.value;
+
+              return (
+                <label
+                  className={cn(
+                    "relative flex cursor-pointer flex-col gap-4 rounded-md border border-slate-700 bg-slate-900/70 p-4 transition-[border-color,background-color,box-shadow] focus-within:border-amber-400 focus-within:shadow-[0_0_0_1px_rgba(245,179,66,0.95),0_0_0_4px_rgba(245,179,66,0.16)]",
+                    checked &&
+                      "border-amber-400 bg-amber-400/10 shadow-[0_0_0_1px_rgba(245,179,66,0.28)]",
+                  )}
+                  htmlFor={`register-role-${option.value.toLowerCase()}`}
+                  key={option.value}
+                >
+                  <input
+                    className="absolute inset-0 cursor-pointer opacity-0"
+                    id={`register-role-${option.value.toLowerCase()}`}
+                    type="radio"
+                    value={option.value}
+                    {...register("role")}
+                  />
+                  <span className="flex items-center justify-between gap-3">
+                    <Icon
+                      aria-hidden="true"
+                      className={cn("h-6 w-6 text-slate-400", checked && "text-amber-400")}
+                    />
+                    <span
+                      aria-hidden="true"
+                      className={cn(
+                        "h-3 w-3 rounded-full border border-slate-600",
+                        checked && "border-amber-400 bg-amber-400",
+                      )}
+                    />
+                  </span>
+                  <span>
+                    <span className="block font-mono text-sm font-semibold uppercase tracking-[0.2em] text-slate-100">
+                      {option.label}
+                    </span>
+                    <span className="mt-2 block text-sm leading-5 text-slate-400">
+                      {option.description}
+                    </span>
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+          {errors.role ? (
+            <p
+              className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--color-danger)]"
+              id={roleErrorId}
+            >
+              {errors.role.message}
+            </p>
+          ) : null}
+        </fieldset>
+
+        <Button className="w-full" loading={isSubmitting} size="lg" type="submit">
           Create account
-        </h1>
-        <p className="text-sm text-slate-500">Register form — coming in SH1 / CA1</p>
-      </div>
-    </main>
+        </Button>
+      </form>
+    </AuthShell>
   );
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
@@ -19,10 +20,12 @@
     "clsx": "^2.1.1",
     "jose": "^6.2.2",
     "leaflet": "^1.9.4",
+    "lucide-react": "^1.14.0",
     "motion": "^12.38.0",
     "next": "^15.3.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.74.0",
     "react-leaflet": "^5.0.0",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.74.0(react@19.2.5))
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -47,6 +50,9 @@ importers:
       leaflet:
         specifier: ^1.9.4
         version: 1.9.4
+      lucide-react:
+        specifier: ^1.14.0
+        version: 1.14.0(react@19.2.5)
       motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -59,6 +65,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.5(react@19.2.5)
+      react-hook-form:
+        specifier: ^7.74.0
+        version: 7.74.0(react@19.2.5)
       react-leaflet:
         specifier: ^5.0.0
         version: 5.0.0(leaflet@1.9.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -870,6 +879,11 @@ packages:
 
   '@hapi/validate@2.0.1':
     resolution: {integrity: sha512-NZmXRnrSLK8MQ9y/CMqE9WSspgB9xA41/LlYR0k967aSZebWr4yNrpxIbov12ICwKy4APSlWXZga9jN5p6puPA==}
+
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -2266,6 +2280,9 @@ packages:
 
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -4379,6 +4396,11 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lucide-react@1.14.0:
+    resolution: {integrity: sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -4843,6 +4865,12 @@ packages:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
       react: ^19.2.5
+
+  react-hook-form@7.74.0:
+    resolution: {integrity: sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -5988,6 +6016,11 @@ snapshots:
     dependencies:
       '@hapi/hoek': 11.0.7
       '@hapi/topo': 6.0.2
+
+  '@hookform/resolvers@5.2.2(react-hook-form@7.74.0(react@19.2.5))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.74.0(react@19.2.5)
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -7581,6 +7614,8 @@ snapshots:
     dependencies:
       color: 5.0.3
       text-hex: 1.0.0
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -10150,6 +10185,10 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lucide-react@1.14.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -10578,6 +10617,10 @@ snapshots:
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
+
+  react-hook-form@7.74.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   react-is@16.13.1: {}
 


### PR DESCRIPTION
Closes #49

Adds ops-console login and registration pages with RHF/Zod validation, role picker, safe next redirects, and register-then-login auth flow.

Verified:
- pnpm --filter web typecheck
- pnpm --filter web lint
- pnpm --filter web build