### PR TITLE
Fix API error message display

### DIFF
--- a/apps/web/lib/api/client.ts
+++ b/apps/web/lib/api/client.ts
@@ -22,7 +22,7 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
     let message = text;
     try {
       const json = JSON.parse(text) as { error?: string; message?: string };
-      message = json.error ?? json.message ?? text;
+      message = json.message ?? json.error ?? text;
     } catch {
       // use raw text
     }


### PR DESCRIPTION
Fixes API error parsing so human-readable backend messages are shown before machine error codes.

Example: registration conflict now displays `Email already registered` instead of `CONFLICT`.

Verified:
- pnpm --filter web typecheck