### PR TITLE
[SH1] Shipper dashboard — KPIs, activity feed, active-routes map

### DIFF
--- a/apps/web/app/(shipper)/shipper/dashboard/page.tsx
+++ b/apps/web/app/(shipper)/shipper/dashboard/page.tsx
@@ -1,14 +1,460 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { useQueries, useQuery } from "@tanstack/react-query";
+import { ArrowRight, CheckCircle2, Gavel, PackagePlus, Truck, XCircle } from "lucide-react";
+import { ActiveRoutesMap, type ActiveRoute } from "@/components/maps/ActiveRoutesMap";
+import { KpiTile } from "@/components/primitives/KpiTile";
+import { MonoNum } from "@/components/primitives/MonoNum";
+import { SectionHeader } from "@/components/primitives/SectionHeader";
+import { StatusPill } from "@/components/primitives/StatusPill";
+import { Table } from "@/components/primitives/Table";
+import * as bidsApi from "@/lib/api/bids";
+import type { Bid } from "@/lib/api/bids";
+import * as loadsApi from "@/lib/api/loads";
+import type { Load, LoadStatus } from "@/lib/api/loads";
+import { getProfile } from "@/lib/api/users";
+
+const ACTIVE_STATUSES: LoadStatus[] = ["Posted", "Matched", "InTransit"];
+const ACTIVE_SET = new Set<LoadStatus>(ACTIVE_STATUSES);
+
+type ActivityEvent = {
+  id: string;
+  timestamp: number;
+  kind: "status" | "bid";
+  description: string;
+  loadTitle: string;
+  status?: LoadStatus;
+  bidStatus?: Bid["status"];
+};
+
+type LoadRow = {
+  _id: string;
+  title: string;
+  origin: string;
+  destination: string;
+  status: LoadStatus;
+  weightKg: number;
+  bidCount: number;
+  updatedAt: string;
+  [key: string]: unknown;
+};
+
 export default function ShipperDashboardPage() {
+  const profileQuery = useQuery({
+    queryKey: ["users", "profile"],
+    queryFn: getProfile,
+  });
+
+  const loadsQuery = useQuery({
+    queryKey: ["loads", "my"],
+    queryFn: loadsApi.list,
+  });
+
+  const loads = React.useMemo(() => loadsQuery.data ?? [], [loadsQuery.data]);
+  const activeLoads = React.useMemo(
+    () => loads.filter((load) => ACTIVE_SET.has(load.status)),
+    [loads],
+  );
+
+  const bidQueries = useQueries({
+    queries: activeLoads.map((load) => ({
+      queryKey: ["bids", "for-load", load._id],
+      queryFn: () => bidsApi.listForLoad(load._id),
+      retry: false,
+      staleTime: 30 * 1000,
+    })),
+  });
+
+  const bidsByLoad = React.useMemo(() => {
+    const map = new Map<string, Bid[]>();
+    activeLoads.forEach((load, index) => {
+      map.set(load._id, bidQueries[index]?.data ?? []);
+    });
+    return map;
+  }, [activeLoads, bidQueries]);
+
+  const totalBidsReceived = React.useMemo(
+    () => activeLoads.reduce((sum, load) => sum + (bidsByLoad.get(load._id)?.length ?? 0), 0),
+    [activeLoads, bidsByLoad],
+  );
+
+  const dollarsInMotion = React.useMemo(() => {
+    return loads
+      .filter((load) => load.status === "InTransit")
+      .reduce((sum, load) => {
+        const accepted = bidsByLoad.get(load._id)?.find((b) => b.status === "Accepted");
+        return sum + (accepted?.priceUSD ?? 0);
+      }, 0);
+  }, [loads, bidsByLoad]);
+
+  const avgTimeToAccept = profileQuery.data?.shipperProfile?.avgTimeToAcceptHours ?? 0;
+
+  const routes: ActiveRoute[] = React.useMemo(
+    () =>
+      activeLoads.map((load) => ({
+        id: load._id,
+        origin: load.origin,
+        destination: load.destination,
+        status: load.status,
+      })),
+    [activeLoads],
+  );
+
+  const activity = React.useMemo(() => buildActivityFeed(loads, bidsByLoad), [loads, bidsByLoad]);
+
+  const recentRows: LoadRow[] = React.useMemo(
+    () =>
+      [...loads]
+        .sort((a, b) => getTimestamp(b.updatedAt) - getTimestamp(a.updatedAt))
+        .slice(0, 8)
+        .map((load) => ({
+          _id: load._id,
+          title: load.title,
+          origin: load.origin,
+          destination: load.destination,
+          status: load.status,
+          weightKg: load.weightKg,
+          bidCount: bidsByLoad.get(load._id)?.length ?? 0,
+          updatedAt: load.updatedAt ?? load.createdAt ?? "",
+        })),
+    [loads, bidsByLoad],
+  );
+
+  const isInitialLoading = loadsQuery.isLoading || profileQuery.isLoading;
+  const hasNoLoads = loadsQuery.isSuccess && loads.length === 0;
+
   return (
-    <div className="px-8 py-12">
-      <p className="font-mono text-xs text-amber-400 uppercase tracking-widest">Shipper</p>
-      <h1
-        className="mt-1 text-2xl font-bold text-slate-100"
-        style={{ fontFamily: "var(--font-display)" }}
-      >
-        Dashboard
-      </h1>
-      <p className="mt-3 text-sm text-slate-500">Shipper dashboard — coming in SH2</p>
+    <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+      <header>
+        <p className="font-mono text-xs uppercase tracking-widest text-amber-400">Shipper</p>
+        <div className="mt-1 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h1
+              className="text-2xl font-bold text-slate-100 sm:text-3xl"
+              style={{ fontFamily: "var(--font-display)" }}
+            >
+              Dashboard
+            </h1>
+            <p className="mt-2 text-sm text-slate-500">
+              Live view of your active lanes, bids, and load activity.
+            </p>
+          </div>
+          <Link
+            href="/shipper/loads/new"
+            className="inline-flex w-fit items-center gap-2 rounded-md border border-amber-400/60 bg-amber-400/10 px-3 py-2 font-mono text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-300 transition-colors hover:bg-amber-400/15"
+          >
+            <PackagePlus className="h-4 w-4" aria-hidden="true" />
+            Post a load
+          </Link>
+        </div>
+      </header>
+
+      {hasNoLoads ? (
+        <EmptyDashboard />
+      ) : (
+        <div className="mt-6 grid grid-cols-12 gap-4">
+          <section className="col-span-12 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <KpiTile label="Active loads" value={activeLoads.length} />
+            <KpiTile label="Bids received" value={totalBidsReceived} />
+            <KpiTile
+              label="Avg time to accept"
+              value={avgTimeToAccept}
+              maximumFractionDigits={1}
+              unit="h"
+            />
+            <KpiTile label="$ in motion" value={dollarsInMotion} currency="USD" />
+          </section>
+
+          <section className="col-span-12 lg:col-span-8">
+            <div className="mb-3 flex items-center justify-between">
+              <SectionHeader label="Active routes" />
+              <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-500">
+                {activeLoads.length} lane{activeLoads.length === 1 ? "" : "s"}
+              </span>
+            </div>
+            {isInitialLoading ? (
+              <MapSkeleton />
+            ) : activeLoads.length === 0 ? (
+              <EmptyMapState />
+            ) : (
+              <ActiveRoutesMap height="360px" routes={routes} />
+            )}
+          </section>
+
+          <section aria-label="Activity feed" className="col-span-12 lg:col-span-4">
+            <div className="mb-3 flex items-center justify-between">
+              <SectionHeader label="Activity" />
+              <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-500">
+                Last {activity.length}
+              </span>
+            </div>
+            <ActivityFeed events={activity} isLoading={isInitialLoading} />
+          </section>
+
+          <section className="col-span-12">
+            <div className="mb-3 flex items-center justify-between">
+              <SectionHeader label="Recent loads" />
+              <Link
+                href="/shipper/loads"
+                className="inline-flex items-center gap-1 font-mono text-[11px] uppercase tracking-[0.18em] text-amber-300 hover:text-amber-200"
+              >
+                See all loads
+                <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+              </Link>
+            </div>
+            {isInitialLoading ? (
+              <TableSkeleton />
+            ) : (
+              <Table<LoadRow>
+                columns={[
+                  {
+                    key: "title",
+                    header: "Load",
+                    sortable: true,
+                    render: (row) => <span className="text-slate-100">{row.title}</span>,
+                  },
+                  {
+                    key: "lane",
+                    header: "Lane",
+                    render: (row) => (
+                      <span className="font-mono text-[12px] text-slate-300">
+                        {row.origin} → {row.destination}
+                      </span>
+                    ),
+                  },
+                  {
+                    key: "status",
+                    header: "Status",
+                    render: (row) => <StatusPill status={row.status} />,
+                  },
+                  {
+                    key: "weightKg",
+                    header: "Weight",
+                    align: "right",
+                    sortable: true,
+                    render: (row) => (
+                      <MonoNum value={row.weightKg} unit="kg" className="text-slate-300" />
+                    ),
+                  },
+                  {
+                    key: "bidCount",
+                    header: "Bids",
+                    align: "right",
+                    sortable: true,
+                    render: (row) => <MonoNum value={row.bidCount} className="text-slate-200" />,
+                  },
+                ]}
+                rows={recentRows}
+                rowKey={(row) => row._id}
+              />
+            )}
+          </section>
+        </div>
+      )}
     </div>
   );
+}
+
+function ActivityFeed({ events, isLoading }: { events: ActivityEvent[]; isLoading: boolean }) {
+  if (isLoading) {
+    return (
+      <ul className="fm-panel-muted divide-y divide-slate-800/70 rounded-lg">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <li key={index} className="flex animate-pulse items-center gap-3 px-3 py-3">
+            <span className="h-3.5 w-3.5 rounded-sm bg-slate-800" />
+            <span className="h-3 flex-1 rounded bg-slate-800" />
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (events.length === 0) {
+    return (
+      <div className="fm-panel-muted rounded-lg px-4 py-8 text-center">
+        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-slate-500">
+          No activity yet
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="fm-panel-muted divide-y divide-slate-800/70 rounded-lg">
+      {events.map((event) => (
+        <li key={event.id} className="flex items-start gap-3 px-3 py-2.5">
+          <span className="mt-0.5 shrink-0 font-mono text-[10px] uppercase tracking-[0.16em] text-slate-500">
+            {formatTimeAgo(event.timestamp)}
+          </span>
+          <ActivityIcon event={event} />
+          <p className="min-w-0 flex-1 text-[13px] leading-snug text-slate-200">
+            <span className="text-slate-400">{event.description}</span>{" "}
+            <span className="text-slate-100">{event.loadTitle}</span>
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ActivityIcon({ event }: { event: ActivityEvent }) {
+  if (event.kind === "bid") {
+    if (event.bidStatus === "Accepted") {
+      return <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-[--color-go]" aria-hidden />;
+    }
+    if (event.bidStatus === "Rejected") {
+      return <XCircle className="h-3.5 w-3.5 shrink-0 text-[--color-danger]" aria-hidden />;
+    }
+    return <Gavel className="h-3.5 w-3.5 shrink-0 text-amber-400" aria-hidden />;
+  }
+  if (event.status === "InTransit") {
+    return <Truck className="h-3.5 w-3.5 shrink-0 text-[--color-transit]" aria-hidden />;
+  }
+  if (event.status === "Delivered") {
+    return <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-[--color-go]" aria-hidden />;
+  }
+  if (event.status === "Cancelled") {
+    return <XCircle className="h-3.5 w-3.5 shrink-0 text-[--color-danger]" aria-hidden />;
+  }
+  return <PackagePlus className="h-3.5 w-3.5 shrink-0 text-amber-400" aria-hidden />;
+}
+
+function MapSkeleton() {
+  return (
+    <div
+      className="fm-panel-muted animate-pulse rounded-xl"
+      style={{ height: "360px" }}
+      aria-hidden
+    />
+  );
+}
+
+function TableSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-lg border border-slate-800">
+      {Array.from({ length: 6 }).map((_, index) => (
+        <div
+          key={index}
+          className="flex animate-pulse items-center gap-3 border-b border-slate-800/70 px-3 py-3 last:border-b-0"
+          style={{ backgroundColor: index % 2 === 0 ? "#121820" : "#151d27" }}
+        >
+          <span className="h-3 w-1/4 rounded bg-slate-800" />
+          <span className="h-3 w-1/3 rounded bg-slate-800" />
+          <span className="h-3 w-16 rounded bg-slate-800" />
+          <span className="ml-auto h-3 w-12 rounded bg-slate-800" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyMapState() {
+  return (
+    <div
+      className="fm-panel-muted flex items-center justify-center rounded-xl"
+      style={{ height: "360px" }}
+    >
+      <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-slate-500">
+        No active routes — post a load to see lanes here
+      </p>
+    </div>
+  );
+}
+
+function EmptyDashboard() {
+  return (
+    <section
+      aria-label="Empty dashboard"
+      className="mt-6 flex flex-col items-center gap-4 rounded-xl border-2 border-amber-400/70 bg-amber-400/5 px-6 py-12 text-center"
+    >
+      <div className="flex h-12 w-12 items-center justify-center rounded-md border border-amber-400/60 bg-slate-950/60 text-amber-300">
+        <PackagePlus className="h-6 w-6" aria-hidden />
+      </div>
+      <div>
+        <h2
+          className="text-xl font-bold text-slate-100"
+          style={{ fontFamily: "var(--font-display)" }}
+        >
+          Create your first load
+        </h2>
+        <p className="mt-2 max-w-md text-sm text-slate-400">
+          Post a lane to start matching with carriers. Bids, routes, and activity will land here in
+          real time.
+        </p>
+      </div>
+      <Link
+        href="/shipper/loads/new"
+        className="inline-flex items-center gap-2 rounded-md border border-amber-400/70 bg-amber-400/15 px-4 py-2 font-mono text-xs font-semibold uppercase tracking-[0.18em] text-amber-200 transition-colors hover:bg-amber-400/25"
+      >
+        <PackagePlus className="h-4 w-4" aria-hidden />
+        Post a load
+      </Link>
+    </section>
+  );
+}
+
+function buildActivityFeed(loads: Load[], bidsByLoad: Map<string, Bid[]>): ActivityEvent[] {
+  const events: ActivityEvent[] = [];
+
+  for (const load of loads) {
+    for (const transition of load.statusHistory ?? []) {
+      const ts = getTimestamp(transition.timestamp);
+      if (!ts) continue;
+      events.push({
+        id: `status:${load._id}:${transition.to}:${ts}`,
+        timestamp: ts,
+        kind: "status",
+        status: transition.to,
+        description: `Status → ${transition.to} on`,
+        loadTitle: load.title,
+      });
+    }
+
+    const bids = bidsByLoad.get(load._id) ?? [];
+    for (const bid of bids) {
+      const ts = getTimestamp(bid.updatedAt ?? bid.createdAt);
+      if (!ts) continue;
+      const description =
+        bid.status === "Accepted"
+          ? `Bid accepted ($${formatPrice(bid.priceUSD)}) on`
+          : bid.status === "Rejected"
+            ? `Bid rejected on`
+            : `New bid ($${formatPrice(bid.priceUSD)}) on`;
+      events.push({
+        id: `bid:${bid._id}:${bid.status}`,
+        timestamp: ts,
+        kind: "bid",
+        bidStatus: bid.status,
+        description,
+        loadTitle: load.title,
+      });
+    }
+  }
+
+  return events.sort((a, b) => b.timestamp - a.timestamp).slice(0, 10);
+}
+
+function getTimestamp(value: string | undefined) {
+  if (!value) return 0;
+  const ts = Date.parse(value);
+  return Number.isFinite(ts) ? ts : 0;
+}
+
+function formatPrice(value: number) {
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(value);
+}
+
+function formatTimeAgo(timestamp: number) {
+  const diff = Date.now() - timestamp;
+  if (diff < 60_000) return "just now";
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d`;
+  const weeks = Math.floor(days / 7);
+  return `${weeks}w`;
 }

--- a/apps/web/components/maps/ActiveRoutesMap.client.tsx
+++ b/apps/web/components/maps/ActiveRoutesMap.client.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import * as React from "react";
+import L, { type LatLngTuple } from "leaflet";
+import { MapContainer, Polyline, TileLayer, useMap } from "react-leaflet";
+import type { LoadStatus } from "@/lib/api/loads";
+import type { ActiveRoute, ActiveRoutesMapProps } from "./ActiveRoutesMap";
+import { RouteMapAsciiFallback, RouteMapFrame, RouteMapLoadingShell } from "./route-map-ui";
+
+type Coordinates = { lat: number; lng: number };
+
+type ResolvedRoute = ActiveRoute & {
+  positions: [LatLngTuple, LatLngTuple];
+};
+
+const CARTO_DARK_MATTER_URL = "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png";
+const CARTO_ATTRIBUTION =
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>';
+
+const STATUS_COLORS: Record<LoadStatus, string> = {
+  Draft: "#94A3B8",
+  Posted: "#F5B342",
+  Matched: "#5BA9F2",
+  InTransit: "#5BA9F2",
+  Delivered: "#3DD68C",
+  Cancelled: "#E0556B",
+};
+
+const geocodeCache = new Map<string, Promise<Coordinates | null>>();
+
+export default function ActiveRoutesMapClient({ height = "360px", routes }: ActiveRoutesMapProps) {
+  const [resolved, setResolved] = React.useState<ResolvedRoute[] | null>(null);
+  const [status, setStatus] = React.useState<"loading" | "ready" | "fallback">("loading");
+
+  const routeKey = React.useMemo(
+    () => routes.map((r) => `${r.id}:${r.origin}->${r.destination}:${r.status}`).join("|"),
+    [routes],
+  );
+
+  React.useEffect(() => {
+    if (routes.length === 0) {
+      setResolved([]);
+      setStatus("ready");
+      return;
+    }
+
+    let active = true;
+    setStatus("loading");
+
+    void Promise.all(
+      routes.map(async (route) => {
+        const [origin, destination] = await Promise.all([
+          geocodeLocation(route.origin),
+          geocodeLocation(route.destination),
+        ]);
+        if (!origin || !destination) return null;
+        return {
+          ...route,
+          positions: [
+            [origin.lat, origin.lng],
+            [destination.lat, destination.lng],
+          ] as [LatLngTuple, LatLngTuple],
+        } satisfies ResolvedRoute;
+      }),
+    ).then((items) => {
+      if (!active) return;
+      const ready = items.filter((item): item is ResolvedRoute => item !== null);
+      if (ready.length === 0) {
+        setStatus("fallback");
+        setResolved([]);
+        return;
+      }
+      setResolved(ready);
+      setStatus("ready");
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [routeKey, routes]);
+
+  if (status === "loading") {
+    return <RouteMapLoadingShell height={height} label="Plotting active lanes" />;
+  }
+
+  if (status === "fallback") {
+    return (
+      <RouteMapAsciiFallback destination="active lanes" height={height} origin="multiple lanes" />
+    );
+  }
+
+  const allPositions = (resolved ?? []).flatMap((r) => r.positions);
+  const bounds = allPositions.length > 0 ? L.latLngBounds(allPositions) : null;
+  const center: LatLngTuple = allPositions[0] ?? [39.8283, -98.5795];
+
+  return (
+    <RouteMapFrame height={height}>
+      <MapContainer
+        attributionControl={false}
+        center={center}
+        className="h-full w-full"
+        scrollWheelZoom={false}
+        zoom={4}
+        zoomControl={false}
+      >
+        <TileLayer attribution={CARTO_ATTRIBUTION} subdomains="abcd" url={CARTO_DARK_MATTER_URL} />
+        {bounds ? <FitToBounds bounds={bounds} /> : null}
+        {(resolved ?? []).map((route) => (
+          <Polyline
+            key={route.id}
+            pathOptions={{
+              color: STATUS_COLORS[route.status] ?? "#F5B342",
+              opacity: 0.85,
+              weight: 2.5,
+              interactive: false,
+            }}
+            positions={route.positions}
+          />
+        ))}
+      </MapContainer>
+      <Legend />
+    </RouteMapFrame>
+  );
+}
+
+function FitToBounds({ bounds }: { bounds: L.LatLngBounds }) {
+  const map = useMap();
+  const key = bounds.toBBoxString();
+
+  React.useEffect(() => {
+    map.fitBounds(bounds, {
+      animate: false,
+      paddingTopLeft: [24, 24],
+      paddingBottomRight: [24, 56],
+    });
+    map.invalidateSize(false);
+  }, [bounds, key, map]);
+
+  return null;
+}
+
+function Legend() {
+  const items: Array<{ label: string; color: string }> = [
+    { label: "Posted", color: STATUS_COLORS.Posted },
+    { label: "Matched", color: STATUS_COLORS.Matched },
+    { label: "In transit", color: STATUS_COLORS.InTransit },
+  ];
+  return (
+    <div className="pointer-events-none absolute bottom-3 left-3 z-[500] flex gap-2 rounded-md border border-slate-700/80 bg-slate-950/82 px-3 py-2 backdrop-blur-sm">
+      {items.map((item) => (
+        <span
+          key={item.label}
+          className="flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-slate-300"
+        >
+          <span
+            className="inline-block h-[2px] w-3 rounded-full"
+            style={{ backgroundColor: item.color }}
+          />
+          {item.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+async function geocodeLocation(value: string): Promise<Coordinates | null> {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return null;
+
+  const cached = geocodeCache.get(normalized);
+  if (cached) return cached;
+
+  const request = fetch(
+    `https://nominatim.openstreetmap.org/search?${new URLSearchParams({
+      q: value.trim(),
+      format: "jsonv2",
+      limit: "1",
+    }).toString()}`,
+    { headers: { Accept: "application/json" } },
+  )
+    .then(async (response) => {
+      if (!response.ok) return null;
+      const payload: unknown = await response.json();
+      if (!Array.isArray(payload) || payload.length === 0) return null;
+      const [first] = payload;
+      if (!first || typeof first !== "object") return null;
+      const lat = Number.parseFloat(String((first as { lat?: unknown }).lat ?? ""));
+      const lon = Number.parseFloat(String((first as { lon?: unknown }).lon ?? ""));
+      if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+      return { lat, lng: lon };
+    })
+    .catch(() => null);
+
+  geocodeCache.set(normalized, request);
+  return request;
+}

--- a/apps/web/components/maps/ActiveRoutesMap.tsx
+++ b/apps/web/components/maps/ActiveRoutesMap.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { CSSProperties } from "react";
+import type { LoadStatus } from "@/lib/api/loads";
+import { RouteMapLoadingShell } from "./route-map-ui";
+
+export type ActiveRoute = {
+  id: string;
+  origin: string;
+  destination: string;
+  status: LoadStatus;
+};
+
+export type ActiveRoutesMapProps = {
+  routes: ActiveRoute[];
+  height?: string;
+};
+
+const ActiveRoutesMapClient = dynamic(() => import("./ActiveRoutesMap.client"), {
+  ssr: false,
+  loading: () => <RouteMapLoadingShell height="var(--fm-route-map-height, 360px)" />,
+});
+
+export function ActiveRoutesMap({ height = "360px", routes }: ActiveRoutesMapProps) {
+  const style = {
+    "--fm-route-map-height": height,
+  } as CSSProperties & { "--fm-route-map-height": string };
+
+  return (
+    <div style={style}>
+      <ActiveRoutesMapClient height={height} routes={routes} />
+    </div>
+  );
+}

--- a/apps/web/lib/api/users.ts
+++ b/apps/web/lib/api/users.ts
@@ -35,8 +35,17 @@ const LoginResponseSchema = z.object({
   user: UserSchema,
 });
 
+const ShipperProfileSchema = z.object({
+  companyName: z.string().nullable().optional(),
+  profilePhotoUrl: z.string().nullable().optional(),
+  bio: z.string().nullable().optional(),
+  completedLoads: z.number().optional(),
+  avgTimeToAcceptHours: z.number().optional(),
+});
+
 const ProfileResponseSchema = UserSchema.extend({
   carrierProfile: CarrierProfileSchema.nullable().optional(),
+  shipperProfile: ShipperProfileSchema.nullable().optional(),
 });
 
 const CarrierProfileResponseSchema = UserSchema.extend({
@@ -45,6 +54,7 @@ const CarrierProfileResponseSchema = UserSchema.extend({
 
 export type User = z.infer<typeof UserSchema>;
 export type CarrierProfile = z.infer<typeof CarrierProfileSchema>;
+export type ShipperProfile = z.infer<typeof ShipperProfileSchema>;
 export type RegisterResponse = z.infer<typeof RegisterResponseSchema>;
 export type LoginResponse = z.infer<typeof LoginResponseSchema>;
 export type ProfileResponse = z.infer<typeof ProfileResponseSchema>;


### PR DESCRIPTION
Closes #51

## Summary
- 4 KPI tiles: active loads, bids received, avg time to accept, `$` in motion
- `ActiveRoutesMap` — multi-polyline leaflet map tinted by load status (Posted/Matched/InTransit), with legend and bounds-fit
- Activity feed — last 10 status transitions + bid events with mono timestamps and per-event icons
- Recent loads table — DS2 `Table` + `StatusPill`, capped at 8 rows, sortable, with \"See all loads →\" link
- Empty state — amber-bordered \"Create your first load\" CTA card when shipper has zero loads
- Skeleton placeholders sized to match final dimensions to avoid layout shift
- Extends web `users` API `ProfileResponse` with `shipperProfile` (so `avgTimeToAcceptHours` is available)

## Test plan
- [ ] Visit `/shipper/dashboard` as a shipper with active loads — KPIs, map, feed, and table render
- [ ] Visit as a shipper with zero loads — empty CTA renders, body sections hidden
- [ ] Tab through the page — order is KPIs → map → feed → table
- [ ] Network throttle — skeletons appear and final layout does not shift on data land