### PR TITLE
[P2] Shipper profile + Settings pages

### DIFF
--- a/apps/web/app/(shared)/settings/page.tsx
+++ b/apps/web/app/(shared)/settings/page.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import * as React from "react";
+import { AlertTriangle, KeyRound, Mail, ShieldAlert } from "lucide-react";
+import { Button } from "@/components/primitives/button";
+import { Input } from "@/components/primitives/input";
+import { SectionHeader } from "@/components/primitives/SectionHeader";
+import { ToastHost, useToastQueue } from "@/components/primitives/ToastHost";
+import { useAuth } from "@/lib/hooks/useAuth";
+
+const NOTIFICATIONS_STORAGE_KEY = "fm:settings:notifications:v1";
+
+type NotificationPrefs = {
+  newBids: boolean;
+  loadStatusChanges: boolean;
+};
+
+const DEFAULT_PREFS: NotificationPrefs = {
+  newBids: true,
+  loadStatusChanges: true,
+};
+
+export default function SettingsPage() {
+  const { user, isLoading } = useAuth();
+  const { toasts, pushToast, dismissToast } = useToastQueue();
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-6 sm:px-6 lg:px-8">
+        <div className="h-8 w-40 animate-pulse rounded bg-slate-800" />
+        <div className="mt-6 space-y-3">
+          <div className="h-32 animate-pulse rounded bg-slate-800/60" />
+          <div className="h-32 animate-pulse rounded bg-slate-800/60" />
+          <div className="h-32 animate-pulse rounded bg-slate-800/60" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
+        <p className="font-mono text-[11px] uppercase tracking-[0.28em] text-slate-500">
+          Sign in required
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-6 sm:px-6 lg:px-8">
+      <header>
+        <p className="font-mono text-xs uppercase tracking-widest text-amber-400">Account</p>
+        <h1
+          className="mt-1 text-2xl font-bold text-slate-100 sm:text-3xl"
+          style={{ fontFamily: "var(--font-display)" }}
+        >
+          Settings
+        </h1>
+        <p className="mt-2 text-sm text-slate-500">
+          Manage credentials, alerts, and account state.
+        </p>
+      </header>
+
+      <div className="mt-8 space-y-6">
+        <EmailSection email={user.email} />
+        <PasswordSection onToast={pushToast} />
+        <NotificationsSection onToast={pushToast} />
+        <DangerZone />
+      </div>
+
+      <ToastHost toasts={toasts} onDismiss={dismissToast} />
+    </div>
+  );
+}
+
+function EmailSection({ email }: { email: string }) {
+  return (
+    <section className="fm-panel-muted rounded-lg p-4">
+      <SectionHeader label="Email" />
+      <div className="mt-4 flex items-center gap-3">
+        <Mail aria-hidden="true" className="h-4 w-4 text-amber-400" />
+        <span className="font-mono text-sm text-slate-200">{email}</span>
+        <span className="ml-auto rounded border border-slate-700 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500">
+          Read only
+        </span>
+      </div>
+      <p className="mt-3 font-mono text-[11px] uppercase tracking-[0.18em] text-slate-500">
+        Contact support to change your email.
+      </p>
+    </section>
+  );
+}
+
+function PasswordSection({
+  onToast,
+}: {
+  onToast: (msg: string, variant?: "info" | "error") => void;
+}) {
+  const [current, setCurrent] = React.useState("");
+  const [next, setNext] = React.useState("");
+  const [confirm, setConfirm] = React.useState("");
+
+  const mismatch = next.length > 0 && confirm.length > 0 && next !== confirm;
+  const tooShort = next.length > 0 && next.length < 8;
+
+  const disabled = !current || !next || !confirm || mismatch || tooShort || next === current;
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    onToast("Password change endpoint pending — coming soon", "error");
+  };
+
+  return (
+    <section className="fm-panel-muted rounded-lg p-4">
+      <div className="flex items-center gap-2">
+        <SectionHeader label="Password" />
+        <span className="ml-auto rounded border border-slate-700 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500">
+          Coming soon
+        </span>
+      </div>
+
+      <form className="mt-4 space-y-4" onSubmit={handleSubmit}>
+        <div>
+          <label
+            className="mb-1 block font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500"
+            htmlFor="current-password"
+          >
+            Current password
+          </label>
+          <Input
+            autoComplete="current-password"
+            id="current-password"
+            onChange={(e) => setCurrent(e.target.value)}
+            type="password"
+            value={current}
+          />
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label
+              className="mb-1 block font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500"
+              htmlFor="new-password"
+            >
+              New password
+            </label>
+            <Input
+              autoComplete="new-password"
+              error={tooShort ? "Min 8 characters" : undefined}
+              id="new-password"
+              onChange={(e) => setNext(e.target.value)}
+              type="password"
+              value={next}
+            />
+          </div>
+          <div>
+            <label
+              className="mb-1 block font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500"
+              htmlFor="confirm-password"
+            >
+              Confirm new
+            </label>
+            <Input
+              autoComplete="new-password"
+              error={mismatch ? "Passwords do not match" : undefined}
+              id="confirm-password"
+              onChange={(e) => setConfirm(e.target.value)}
+              type="password"
+              value={confirm}
+            />
+          </div>
+        </div>
+        <div className="flex items-center justify-end">
+          <Button disabled={disabled} type="submit" variant="secondary">
+            <KeyRound aria-hidden="true" className="h-3.5 w-3.5" />
+            Change password
+          </Button>
+        </div>
+      </form>
+    </section>
+  );
+}
+
+function NotificationsSection({
+  onToast,
+}: {
+  onToast: (msg: string, variant?: "info" | "error") => void;
+}) {
+  const [prefs, setPrefs] = React.useState<NotificationPrefs>(DEFAULT_PREFS);
+  const [hydrated, setHydrated] = React.useState(false);
+
+  React.useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(NOTIFICATIONS_STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as Partial<NotificationPrefs>;
+        setPrefs({
+          newBids: parsed.newBids ?? DEFAULT_PREFS.newBids,
+          loadStatusChanges: parsed.loadStatusChanges ?? DEFAULT_PREFS.loadStatusChanges,
+        });
+      }
+    } catch {
+      // ignore corrupt local state
+    }
+    setHydrated(true);
+  }, []);
+
+  const toggle = (key: keyof NotificationPrefs) => {
+    setPrefs((prev) => {
+      const nextPrefs = { ...prev, [key]: !prev[key] };
+      try {
+        window.localStorage.setItem(NOTIFICATIONS_STORAGE_KEY, JSON.stringify(nextPrefs));
+      } catch {
+        // localStorage may be disabled
+      }
+      onToast("Preference saved");
+      return nextPrefs;
+    });
+  };
+
+  return (
+    <section className="fm-panel-muted rounded-lg p-4">
+      <div className="flex items-center gap-2">
+        <SectionHeader label="Notifications" />
+        <span className="ml-auto rounded border border-slate-700 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500">
+          Coming soon
+        </span>
+      </div>
+
+      <div className="mt-4 space-y-3">
+        <ToggleRow
+          checked={prefs.newBids}
+          disabled={!hydrated}
+          label="Email me on new bids"
+          onChange={() => toggle("newBids")}
+        />
+        <ToggleRow
+          checked={prefs.loadStatusChanges}
+          disabled={!hydrated}
+          label="Email me on load status changes"
+          onChange={() => toggle("loadStatusChanges")}
+        />
+      </div>
+
+      <p className="mt-4 font-mono text-[11px] uppercase tracking-[0.18em] text-slate-500">
+        Saved locally until the notifications service ships.
+      </p>
+    </section>
+  );
+}
+
+function ToggleRow({
+  checked,
+  disabled,
+  label,
+  onChange,
+}: {
+  checked: boolean;
+  disabled?: boolean;
+  label: string;
+  onChange: () => void;
+}) {
+  return (
+    <label className="flex cursor-pointer items-center justify-between gap-3 rounded border border-slate-800 bg-slate-950/40 px-3 py-2.5 hover:border-slate-700">
+      <span className="text-sm text-slate-200">{label}</span>
+      <input
+        checked={checked}
+        className="h-4 w-4 cursor-pointer accent-amber-400"
+        disabled={disabled}
+        onChange={onChange}
+        type="checkbox"
+      />
+    </label>
+  );
+}
+
+function DangerZone() {
+  return (
+    <section className="rounded-lg border border-[--color-danger]/40 bg-[--color-danger]/5 p-4">
+      <div className="flex items-center gap-2">
+        <ShieldAlert aria-hidden="true" className="h-4 w-4 text-[--color-danger]" />
+        <h2 className="font-mono text-xs uppercase tracking-widest text-[--color-danger]">
+          Danger zone
+        </h2>
+      </div>
+
+      <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm text-slate-200">Delete account</p>
+          <p className="mt-1 font-mono text-[11px] uppercase tracking-[0.18em] text-slate-500">
+            Permanently removes your data. Contact support to proceed.
+          </p>
+        </div>
+        <span title="Contact support to proceed">
+          <Button disabled type="button" variant="danger">
+            <AlertTriangle aria-hidden="true" className="h-3.5 w-3.5" />
+            Delete account
+          </Button>
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/(shipper)/profile/page.tsx
+++ b/apps/web/app/(shipper)/profile/page.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import * as React from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ImagePlus, Save } from "lucide-react";
+import { Button } from "@/components/primitives/button";
+import { Input } from "@/components/primitives/input";
+import { KpiTile } from "@/components/primitives/KpiTile";
+import { SectionHeader } from "@/components/primitives/SectionHeader";
+import { ToastHost, useToastQueue } from "@/components/primitives/ToastHost";
+import { useAuth } from "@/lib/hooks/useAuth";
+import { ApiResponseError } from "@/lib/api/client";
+import {
+  getProfile,
+  updateShipperProfile,
+  type ProfileResponse,
+  type ShipperProfile,
+} from "@/lib/api/users";
+
+const BIO_MAX = 500;
+const COMPANY_MAX = 200;
+
+export default function ShipperProfilePage() {
+  const { user, isLoading: authLoading } = useAuth();
+  const { toasts, pushToast, dismissToast } = useToastQueue();
+  const queryClient = useQueryClient();
+
+  const profileQuery = useQuery({
+    queryKey: ["users", "profile"],
+    queryFn: getProfile,
+    enabled: Boolean(user),
+  });
+
+  if (authLoading || (profileQuery.isLoading && !profileQuery.data)) {
+    return <PageSkeleton />;
+  }
+
+  if (user && user.role !== "Shipper") {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
+        <p className="font-mono text-[11px] uppercase tracking-[0.28em] text-slate-500">
+          Shipper account required
+        </p>
+      </div>
+    );
+  }
+
+  if (!profileQuery.data) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
+        <p className="font-mono text-[11px] uppercase tracking-[0.28em] text-[--color-danger]">
+          Failed to load profile
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ProfileForm
+      onError={(msg) => pushToast(msg, "error")}
+      onSuccess={(msg) => pushToast(msg, "info")}
+      profile={profileQuery.data}
+      queryClient={queryClient}
+      toastHost={<ToastHost toasts={toasts} onDismiss={dismissToast} />}
+    />
+  );
+}
+
+function ProfileForm({
+  profile,
+  queryClient,
+  onSuccess,
+  onError,
+  toastHost,
+}: {
+  profile: ProfileResponse;
+  queryClient: ReturnType<typeof useQueryClient>;
+  onSuccess: (msg: string) => void;
+  onError: (msg: string) => void;
+  toastHost: React.ReactNode;
+}) {
+  const shipper: ShipperProfile = profile.shipperProfile ?? {};
+  const [companyName, setCompanyName] = React.useState(shipper.companyName ?? "");
+  const [bio, setBio] = React.useState(shipper.bio ?? "");
+  const [photoUrl, setPhotoUrl] = React.useState(shipper.profilePhotoUrl ?? "");
+
+  const initial = React.useMemo(
+    () => ({
+      companyName: shipper.companyName ?? "",
+      bio: shipper.bio ?? "",
+      photoUrl: shipper.profilePhotoUrl ?? "",
+    }),
+    [shipper.companyName, shipper.bio, shipper.profilePhotoUrl],
+  );
+
+  const isDirty =
+    companyName !== initial.companyName || bio !== initial.bio || photoUrl !== initial.photoUrl;
+
+  const companyError =
+    companyName.length > COMPANY_MAX ? `Max ${COMPANY_MAX} characters` : undefined;
+  const bioError = bio.length > BIO_MAX ? `Max ${BIO_MAX} characters` : undefined;
+  const hasError = Boolean(companyError || bioError);
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      updateShipperProfile({
+        companyName: companyName.trim() ? companyName.trim() : null,
+        bio: bio.trim() ? bio.trim() : null,
+        profilePhotoUrl: photoUrl.trim() ? photoUrl.trim() : null,
+      }),
+    onSuccess: (data) => {
+      queryClient.setQueryData<ProfileResponse>(["users", "profile"], (prev) =>
+        prev ? { ...prev, shipperProfile: data.shipperProfile } : prev,
+      );
+      onSuccess("Profile saved");
+    },
+    onError: (err: unknown) => {
+      const message = err instanceof ApiResponseError ? err.message : "Failed to save profile";
+      onError(message);
+    },
+  });
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (hasError) return;
+    mutation.mutate();
+  };
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-6 sm:px-6 lg:px-8">
+      <header>
+        <p className="font-mono text-xs uppercase tracking-widest text-amber-400">Shipper</p>
+        <h1
+          className="mt-1 text-2xl font-bold text-slate-100 sm:text-3xl"
+          style={{ fontFamily: "var(--font-display)" }}
+        >
+          Profile
+        </h1>
+        <p className="mt-2 text-sm text-slate-500">
+          Public information shippers see when you bid on their loads.
+        </p>
+      </header>
+
+      <section className="mt-6 grid gap-3 sm:grid-cols-2">
+        <KpiTile label="Completed loads" value={profile.shipperProfile?.completedLoads ?? 0} />
+        <KpiTile
+          label="Avg time to accept"
+          value={profile.shipperProfile?.avgTimeToAcceptHours ?? 0}
+          maximumFractionDigits={1}
+          unit="h"
+        />
+      </section>
+
+      <form className="mt-8 grid gap-6 lg:grid-cols-[240px_minmax(0,1fr)]" onSubmit={handleSubmit}>
+        <div className="fm-panel-muted rounded-lg p-4">
+          <SectionHeader label="Photo" />
+          <div className="mt-4 flex flex-col items-center gap-3">
+            <PhotoPreview url={photoUrl} />
+            <div className="w-full">
+              <label
+                className="mb-1 block font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500"
+                htmlFor="photo-url"
+              >
+                Photo URL
+              </label>
+              <Input
+                id="photo-url"
+                onChange={(e) => setPhotoUrl(e.target.value)}
+                placeholder="https://…"
+                type="url"
+                value={photoUrl}
+              />
+            </div>
+            <p className="font-mono text-[10px] leading-relaxed tracking-[0.12em] text-slate-500">
+              File upload lands in P1. URL works today.
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          <div className="fm-panel-muted rounded-lg p-4">
+            <SectionHeader label="Company" />
+            <div className="mt-4 space-y-4">
+              <div>
+                <label
+                  className="mb-1 block font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500"
+                  htmlFor="company-name"
+                >
+                  Company name
+                </label>
+                <Input
+                  error={companyError}
+                  id="company-name"
+                  maxLength={COMPANY_MAX + 50}
+                  onChange={(e) => setCompanyName(e.target.value)}
+                  placeholder="Acme Logistics"
+                  value={companyName}
+                />
+              </div>
+
+              <div>
+                <div className="mb-1 flex items-baseline justify-between">
+                  <label
+                    className="block font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500"
+                    htmlFor="bio"
+                  >
+                    Bio
+                  </label>
+                  <span className="font-mono text-[10px] tabular-nums text-slate-600">
+                    {bio.length} / {BIO_MAX}
+                  </span>
+                </div>
+                <textarea
+                  className="fm-focus-ring w-full rounded-md border border-slate-700 bg-slate-800/95 px-3.5 py-3 font-mono text-sm text-slate-100 placeholder:text-slate-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]"
+                  id="bio"
+                  maxLength={BIO_MAX + 50}
+                  onChange={(e) => setBio(e.target.value)}
+                  placeholder="A short description of your operation."
+                  rows={5}
+                  value={bio}
+                />
+                {bioError ? (
+                  <p className="mt-1 font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--color-danger)]">
+                    {bioError}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-end gap-3">
+            <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-slate-500">
+              {isDirty ? "Unsaved changes" : "Up to date"}
+            </p>
+            <Button
+              disabled={!isDirty || hasError || mutation.isPending}
+              loading={mutation.isPending}
+              type="submit"
+              variant="primary"
+            >
+              <Save aria-hidden="true" className="h-3.5 w-3.5" />
+              Save
+            </Button>
+          </div>
+        </div>
+      </form>
+
+      {toastHost}
+    </div>
+  );
+}
+
+function PhotoPreview({ url }: { url: string }) {
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return (
+      <div className="flex h-32 w-32 items-center justify-center rounded-full border border-dashed border-slate-700 bg-slate-900/60 text-slate-600">
+        <ImagePlus className="h-6 w-6" aria-hidden="true" />
+      </div>
+    );
+  }
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      alt=""
+      className="h-32 w-32 rounded-full border border-slate-700 object-cover"
+      src={trimmed}
+    />
+  );
+}
+
+function PageSkeleton() {
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-6 sm:px-6 lg:px-8">
+      <div className="h-8 w-40 animate-pulse rounded bg-slate-800" />
+      <div className="mt-6 grid gap-3 sm:grid-cols-2">
+        <div className="h-20 animate-pulse rounded bg-slate-800/60" />
+        <div className="h-20 animate-pulse rounded bg-slate-800/60" />
+      </div>
+      <div className="mt-8 grid gap-6 lg:grid-cols-[240px_minmax(0,1fr)]">
+        <div className="h-64 animate-pulse rounded bg-slate-800/60" />
+        <div className="h-64 animate-pulse rounded bg-slate-800/60" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/Navbar.tsx
+++ b/apps/web/components/Navbar.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import * as React from "react";
 import Link from "next/link";
+import { LogOut, Settings as SettingsIcon, UserCircle } from "lucide-react";
 import { useAuth } from "@/lib/hooks/useAuth";
 
 export function Navbar() {
@@ -36,20 +38,121 @@ export function Navbar() {
             {user.role}
           </span>
 
-          <div className="h-7 w-7 rounded-full bg-slate-700 border border-slate-600 flex items-center justify-center">
-            <span className="font-mono text-xs text-slate-300 uppercase">
-              {user.email.charAt(0)}
-            </span>
-          </div>
-
-          <button
-            onClick={() => void logout()}
-            className="font-mono text-xs text-slate-400 hover:text-slate-200 transition-colors"
-          >
-            logout
-          </button>
+          <UserMenu
+            email={user.email}
+            isShipper={user.role === "Shipper"}
+            onLogout={() => void logout()}
+          />
         </>
       )}
     </header>
+  );
+}
+
+function UserMenu({
+  email,
+  isShipper,
+  onLogout,
+}: {
+  email: string;
+  isShipper: boolean;
+  onLogout: () => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const handlePointer = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", handlePointer);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handlePointer);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label="Account menu"
+        className="fm-focus-ring flex h-7 w-7 items-center justify-center rounded-full border border-slate-600 bg-slate-700 transition-colors hover:border-amber-400/60 hover:bg-slate-600"
+        onClick={() => setOpen((v) => !v)}
+        type="button"
+      >
+        <span className="font-mono text-xs uppercase text-slate-300">{email.charAt(0)}</span>
+      </button>
+
+      {open ? (
+        <div
+          className="absolute right-0 top-full z-50 mt-2 w-56 overflow-hidden rounded-md border border-slate-800 bg-slate-900/95 shadow-lg backdrop-blur"
+          role="menu"
+        >
+          <div className="border-b border-slate-800 px-3 py-2">
+            <p className="truncate font-mono text-[11px] text-slate-300">{email}</p>
+          </div>
+
+          {isShipper ? (
+            <MenuLink
+              href="/profile"
+              icon={<UserCircle aria-hidden="true" className="h-3.5 w-3.5" />}
+              label="Profile"
+              onSelect={() => setOpen(false)}
+            />
+          ) : null}
+
+          <MenuLink
+            href="/settings"
+            icon={<SettingsIcon aria-hidden="true" className="h-3.5 w-3.5" />}
+            label="Settings"
+            onSelect={() => setOpen(false)}
+          />
+
+          <button
+            className="flex w-full items-center gap-2 border-t border-slate-800 px-3 py-2 text-left font-mono text-xs uppercase tracking-[0.2em] text-slate-400 transition-colors hover:bg-slate-800/80 hover:text-[--color-danger]"
+            onClick={() => {
+              setOpen(false);
+              onLogout();
+            }}
+            role="menuitem"
+            type="button"
+          >
+            <LogOut aria-hidden="true" className="h-3.5 w-3.5" />
+            Logout
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function MenuLink({
+  href,
+  icon,
+  label,
+  onSelect,
+}: {
+  href: string;
+  icon: React.ReactNode;
+  label: string;
+  onSelect: () => void;
+}) {
+  return (
+    <Link
+      className="flex items-center gap-2 px-3 py-2 font-mono text-xs uppercase tracking-[0.2em] text-slate-300 transition-colors hover:bg-slate-800/80 hover:text-amber-300"
+      href={href}
+      onClick={onSelect}
+      role="menuitem"
+    >
+      {icon}
+      {label}
+    </Link>
   );
 }

--- a/apps/web/lib/api/users.ts
+++ b/apps/web/lib/api/users.ts
@@ -52,6 +52,10 @@ const CarrierProfileResponseSchema = UserSchema.extend({
   carrierProfile: CarrierProfileSchema.nullable(),
 });
 
+const ShipperProfileResponseSchema = UserSchema.extend({
+  shipperProfile: ShipperProfileSchema.nullable(),
+});
+
 export type User = z.infer<typeof UserSchema>;
 export type CarrierProfile = z.infer<typeof CarrierProfileSchema>;
 export type ShipperProfile = z.infer<typeof ShipperProfileSchema>;
@@ -74,6 +78,12 @@ export type UpdateCarrierProfileInput = {
   truckType?: z.infer<typeof TruckTypeSchema>;
   capacityKg?: number;
   homeCity?: string;
+  profilePhotoUrl?: string | null;
+  bio?: string | null;
+};
+
+export type UpdateShipperProfileInput = {
+  companyName?: string | null;
   profilePhotoUrl?: string | null;
   bio?: string | null;
 };
@@ -120,4 +130,14 @@ export async function updateCarrierProfile(
     body: JSON.stringify(input),
   });
   return CarrierProfileResponseSchema.parse(data);
+}
+
+export async function updateShipperProfile(
+  input: UpdateShipperProfileInput,
+): Promise<z.infer<typeof ShipperProfileResponseSchema>> {
+  const data = await apiFetch<unknown>("api/users/shipper-profile", {
+    method: "PATCH",
+    body: JSON.stringify(input),
+  });
+  return ShipperProfileResponseSchema.parse(data);
 }


### PR DESCRIPTION
Closes #59.

## Summary
- **`/profile` (Shipper):** company name, bio, photo URL with stats tiles (`completedLoads`, `avgTimeToAcceptHours`). PATCH `/api/users/shipper-profile`, optimistic cache update, toast on success/error.
- **`/settings` (Shipper + Carrier):** read-only email, password change form (stubbed — surfaces "coming soon" toast since no endpoint exists yet), notification toggles persisted to `localStorage` under `fm:settings:notifications:v1`, and a danger zone with disabled "Delete account" button + contact-support tooltip.
- **`lib/api/users.ts`:** adds `updateShipperProfile` + `ShipperProfileResponseSchema` + `UpdateShipperProfileInput`.

## Notes
- File-upload UI is deferred to **P1** (per spec). The current photo field accepts a URL, which matches the backend column type (`profilePhotoUrl: string`).
- Password change endpoint does not exist in `user-service`; spec allows stubbing with a note. The form validates client-side (length + match) and toasts a clear "endpoint pending" message on submit.
- `/settings` lives under `(shared)` so the same route serves both Shipper and Carrier roles.

## Test plan
- [ ] Sign in as Shipper → `/profile` loads existing values, save mutates and shows toast
- [ ] Bio counter shows `n / 500` and blocks save past max
- [ ] `/settings` accessible to both Shipper and Carrier
- [ ] Notification toggles persist across reload
- [ ] Password form validates mismatch + min length, shows "coming soon" toast on submit
- [ ] Delete account button is disabled and surfaces tooltip