### PR TITLE
feat(user-service): trust-score util with full test coverage

### DIFF
--- a/services/user-service/src/utils/__tests__/trust-score.util.test.ts
+++ b/services/user-service/src/utils/__tests__/trust-score.util.test.ts
@@ -1,0 +1,154 @@
+import { computeTrustScore } from '../trust-score.util';
+
+describe('computeTrustScore', () => {
+  describe('new carriers', () => {
+    it('returns 0 when completedCount is 0, regardless of rating', () => {
+      expect(
+        computeTrustScore({ rating: 5, onTimeRate: 1, completedCount: 0 }),
+      ).toBe(0);
+    });
+
+    it('returns 0 when completedCount is negative', () => {
+      expect(
+        computeTrustScore({ rating: 5, onTimeRate: 1, completedCount: -10 }),
+      ).toBe(0);
+    });
+  });
+
+  describe('canonical scenarios', () => {
+    it('scores a perfect carrier at 100', () => {
+      expect(
+        computeTrustScore({ rating: 5, onTimeRate: 1, completedCount: 50 }),
+      ).toBe(100);
+    });
+
+    it('scores a perfect carrier with extra experience at 100 (capped)', () => {
+      expect(
+        computeTrustScore({ rating: 5, onTimeRate: 1, completedCount: 500 }),
+      ).toBe(100);
+    });
+
+    it('scores a mediocre carrier in a sensible middle range', () => {
+      const score = computeTrustScore({
+        rating: 3,
+        onTimeRate: 0.8,
+        completedCount: 20,
+      });
+      // rating 30 + onTime 24 + experience 8 = 62
+      expect(score).toBe(62);
+      expect(score).toBeGreaterThan(30);
+      expect(score).toBeLessThan(80);
+    });
+
+    it('scores a single-load new-ish carrier with low signal', () => {
+      // rating 50 + onTime 30 + experience 0.4 = 80.4 -> 80
+      expect(
+        computeTrustScore({ rating: 5, onTimeRate: 1, completedCount: 1 }),
+      ).toBe(80);
+    });
+  });
+
+  describe('component weighting', () => {
+    it('rating component contributes up to 50 points', () => {
+      const score = computeTrustScore({
+        rating: 5,
+        onTimeRate: 0,
+        completedCount: 1,
+      });
+      // rating 50 + onTime 0 + experience 0.4 = 50.4 -> 50
+      expect(score).toBe(50);
+    });
+
+    it('on-time component contributes up to 30 points', () => {
+      const score = computeTrustScore({
+        rating: 0,
+        onTimeRate: 1,
+        completedCount: 1,
+      });
+      // rating 0 + onTime 30 + experience 0.4 = 30.4 -> 30
+      expect(score).toBe(30);
+    });
+
+    it('experience component contributes up to 20 points and saturates at 50 completions', () => {
+      const score50 = computeTrustScore({
+        rating: 0,
+        onTimeRate: 0,
+        completedCount: 50,
+      });
+      const score200 = computeTrustScore({
+        rating: 0,
+        onTimeRate: 0,
+        completedCount: 200,
+      });
+      expect(score50).toBe(20);
+      expect(score200).toBe(20);
+    });
+  });
+
+  describe('clamping and bad input', () => {
+    it('clamps rating above 5 to a perfect rating component', () => {
+      expect(
+        computeTrustScore({ rating: 999, onTimeRate: 1, completedCount: 50 }),
+      ).toBe(100);
+    });
+
+    it('clamps negative rating to 0', () => {
+      // rating 0 + onTime 30 + experience 20 = 50
+      expect(
+        computeTrustScore({ rating: -3, onTimeRate: 1, completedCount: 50 }),
+      ).toBe(50);
+    });
+
+    it('clamps onTimeRate above 1', () => {
+      expect(
+        computeTrustScore({ rating: 5, onTimeRate: 999, completedCount: 50 }),
+      ).toBe(100);
+    });
+
+    it('clamps negative onTimeRate to 0', () => {
+      // rating 50 + onTime 0 + experience 20 = 70
+      expect(
+        computeTrustScore({ rating: 5, onTimeRate: -1, completedCount: 50 }),
+      ).toBe(70);
+    });
+
+    it('returns 0 when any input is NaN', () => {
+      expect(
+        computeTrustScore({ rating: NaN, onTimeRate: 1, completedCount: 50 }),
+      ).toBe(0);
+      expect(
+        computeTrustScore({ rating: 5, onTimeRate: NaN, completedCount: 50 }),
+      ).toBe(0);
+      expect(
+        computeTrustScore({ rating: 5, onTimeRate: 1, completedCount: NaN }),
+      ).toBe(0);
+    });
+
+    it('returns 0 when any input is Infinity', () => {
+      expect(
+        computeTrustScore({ rating: Infinity, onTimeRate: 1, completedCount: 50 }),
+      ).toBe(0);
+      expect(
+        computeTrustScore({ rating: 5, onTimeRate: 1, completedCount: Infinity }),
+      ).toBe(0);
+    });
+  });
+
+  describe('output guarantees', () => {
+    it('always returns an integer in [0, 100]', () => {
+      const samples: Array<{ rating: number; onTimeRate: number; completedCount: number }> = [
+        { rating: 0, onTimeRate: 0, completedCount: 1 },
+        { rating: 2.5, onTimeRate: 0.5, completedCount: 7 },
+        { rating: 4.2, onTimeRate: 0.91, completedCount: 33 },
+        { rating: 5, onTimeRate: 1, completedCount: 100 },
+      ];
+
+      for (const input of samples) {
+        const score = computeTrustScore(input);
+        expect(Number.isInteger(score)).toBe(true);
+        expect(score).toBeGreaterThanOrEqual(0);
+        expect(score).toBeLessThanOrEqual(100);
+      }
+    });
+  });
+});

--- a/services/user-service/src/utils/trust-score.util.ts
+++ b/services/user-service/src/utils/trust-score.util.ts
@@ -1,0 +1,29 @@
+export interface TrustScoreInput {
+  rating: number;
+  onTimeRate: number;
+  completedCount: number;
+}
+
+export function computeTrustScore(input: TrustScoreInput): number {
+  const { rating, onTimeRate, completedCount } = input;
+
+  if (!Number.isFinite(rating) || !Number.isFinite(onTimeRate) || !Number.isFinite(completedCount)) {
+    return 0;
+  }
+
+  if (completedCount <= 0) {
+    return 0;
+  }
+
+  const safeRating = Math.min(Math.max(rating, 0), 5);
+  const safeOnTime = Math.min(Math.max(onTimeRate, 0), 1);
+  const safeCount = Math.max(completedCount, 0);
+
+  const ratingComponent = (safeRating / 5) * 50;
+  const onTimeComponent = safeOnTime * 30;
+  const experienceComponent = Math.min(safeCount / 50, 1) * 20;
+
+  const total = ratingComponent + onTimeComponent + experienceComponent;
+
+  return Math.min(Math.max(Math.round(total), 0), 100);
+}


### PR DESCRIPTION
Closes #44.

## Summary
- New `services/user-service/src/utils/trust-score.util.ts` with a pure `computeTrustScore({ rating, onTimeRate, completedCount })` returning an integer in `[0, 100]`.
- Formula straight from the issue:
  - `ratingComponent = (rating / 5) * 50`
  - `onTimeComponent = onTimeRate * 30`
  - `experienceComponent = min(completedCount / 50, 1) * 20`
- New carriers (`completedCount <= 0`) → `0` (no signal, not a low score).
- `NaN` / `Infinity` inputs are treated as missing data → `0`. Any other out-of-range inputs are clamped so the result stays in `[0, 100]`.

## Tests
`services/user-service/src/utils/__tests__/trust-score.util.test.ts` — 16 cases covering:
- New carriers (zero / negative completion count)
- Perfect carrier → 100; perfect carrier with extra experience also 100 (cap)
- Mediocre carrier (3 / 0.8 / 20) → 62 (sanity middle)
- Component weighting (rating ≤ 50, on-time ≤ 30, experience ≤ 20 and saturating at 50)
- Clamping (rating > 5, rating < 0, onTimeRate > 1 and < 0)
- NaN and Infinity → 0
- Output is always an integer in `[0, 100]`

## Coverage
`jest --coverage` reports **100%** statements / branches / functions / lines on `trust-score.util.ts`.

## Notes
- File is named `trust-score.util.test.ts` (not `.spec.ts` as the issue suggested) to match the existing convention in `services/user-service` (`testMatch: '**/__tests__/**/*.test.ts'`).
- No `services/user-service/src/utils/index.ts` barrel exists, so consumers should import from the file directly. Happy to add one if preferred.
- Existing `validators.test.ts` fails locally because it pulls `routes/user.routes.ts → middlewares/auth.middleware.ts → config/env.ts`, which calls `process.exit(1)` when `.env` is absent. Pre-existing, unrelated to this PR.

## Test plan
- [x] `pnpm --filter @freightmatch/user-service exec jest --testPathPattern=trust-score` — 16/16 pass
- [x] `pnpm --filter @freightmatch/user-service typecheck` — green
- [x] Coverage 100% on the util

🤖 Generated with [Claude Code](https://claude.com/claude-code)