### PR TITLE
feat(web): carrier marketplace with cards/map views and bid drawer

### DIFF
--- a/apps/web/app/(carrier)/marketplace/[id]/page.tsx
+++ b/apps/web/app/(carrier)/marketplace/[id]/page.tsx
@@ -1,0 +1,841 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ArrowLeft,
+  CheckCircle2,
+  Clock3,
+  DollarSign,
+  Gauge,
+  PackageCheck,
+  Send,
+  Star,
+  Truck,
+  XCircle,
+} from "lucide-react";
+import { RouteMap } from "@/components/maps/RouteMap";
+import { Button } from "@/components/primitives/button";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/primitives/drawer";
+import { Input } from "@/components/primitives/input";
+import { MonoNum } from "@/components/primitives/MonoNum";
+import { SectionHeader } from "@/components/primitives/SectionHeader";
+import { StatusPill } from "@/components/primitives/StatusPill";
+import { ToastHost, useToastQueue } from "@/components/primitives/ToastHost";
+import { ApiResponseError } from "@/lib/api/client";
+import * as bidsApi from "@/lib/api/bids";
+import type { Bid, CreateBidInput } from "@/lib/api/bids";
+import * as loadsApi from "@/lib/api/loads";
+import type { Load } from "@/lib/api/loads";
+import { getProfile, getUserById, type ProfileResponse } from "@/lib/api/users";
+
+const MIN_PRICE = 1;
+const MAX_PRICE = 1_000_000;
+const MIN_HOURS = 1;
+const MAX_HOURS = 720;
+
+export default function CarrierLoadDetailPage() {
+  const params = useParams<{ id: string }>();
+  const loadId = params?.id;
+  const queryClient = useQueryClient();
+  const { toasts, pushToast, dismissToast } = useToastQueue();
+
+  const profileQuery = useQuery({
+    queryKey: ["users", "profile"],
+    queryFn: getProfile,
+  });
+
+  const loadQuery = useQuery({
+    queryKey: ["loads", loadId],
+    queryFn: () => loadsApi.get(loadId!),
+    enabled: Boolean(loadId),
+  });
+
+  const myBidsQuery = useQuery({
+    queryKey: ["bids", "my"],
+    queryFn: bidsApi.listMine,
+  });
+
+  const otherBidsQuery = useQuery({
+    queryKey: ["bids", "for-load", loadId],
+    queryFn: () => bidsApi.listForLoad(loadId!),
+    enabled: Boolean(loadId),
+    retry: (failureCount, error) => {
+      if (error instanceof ApiResponseError && (error.status === 401 || error.status === 403)) {
+        return false;
+      }
+      return failureCount < 1;
+    },
+  });
+
+  const shipperId = loadQuery.data?.shipperId;
+  const shipperQuery = useQuery({
+    queryKey: ["users", shipperId ?? "_none"],
+    queryFn: () => getUserById(shipperId!),
+    enabled: Boolean(shipperId),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+
+  const carrierProfile = profileQuery.data?.carrierProfile ?? null;
+  const isProfileComplete = Boolean(
+    carrierProfile?.truckType && carrierProfile?.capacityKg && carrierProfile.capacityKg > 0,
+  );
+
+  const myBidForLoad = React.useMemo<Bid | null>(() => {
+    if (!loadId) return null;
+    const bid = myBidsQuery.data?.find((entry) => entry.loadId === loadId);
+    return bid ?? null;
+  }, [loadId, myBidsQuery.data]);
+
+  const otherBids = React.useMemo<Bid[]>(() => {
+    if (!otherBidsQuery.data) return [];
+    return otherBidsQuery.data.filter((bid) => bid._id !== myBidForLoad?._id);
+  }, [otherBidsQuery.data, myBidForLoad]);
+
+  const marketAvgEta = React.useMemo(() => {
+    if (otherBids.length === 0) return null;
+    const total = otherBids.reduce((sum, bid) => sum + bid.estimatedDeliveryHours, 0);
+    return total / otherBids.length;
+  }, [otherBids]);
+
+  const [drawerOpen, setDrawerOpen] = React.useState(false);
+  const [priceInput, setPriceInput] = React.useState("");
+  const [hoursInput, setHoursInput] = React.useState("24");
+  const [notes, setNotes] = React.useState("");
+
+  const handleOpenDrawer = React.useCallback(() => {
+    if (!isProfileComplete || myBidForLoad) {
+      setDrawerOpen(true);
+      return;
+    }
+    const suggestedHours = loadQuery.data?.deadlineHours
+      ? Math.max(MIN_HOURS, Math.min(loadQuery.data.deadlineHours, MAX_HOURS))
+      : 24;
+    setPriceInput("");
+    setHoursInput(String(suggestedHours));
+    setNotes("");
+    setDrawerOpen(true);
+  }, [isProfileComplete, loadQuery.data?.deadlineHours, myBidForLoad]);
+
+  const submitMutation = useMutation({
+    mutationFn: (input: CreateBidInput) => bidsApi.create(input),
+    onSuccess: (bid) => {
+      queryClient.setQueryData<Bid[]>(["bids", "my"], (prev) => {
+        const existing = prev ?? [];
+        if (existing.some((b) => b._id === bid._id)) return existing;
+        return [bid, ...existing];
+      });
+      void queryClient.invalidateQueries({ queryKey: ["bids"] });
+      pushToast("Bid submitted");
+      setDrawerOpen(false);
+    },
+    onError: (error: unknown) => {
+      pushToast(messageFromBidError(error), "error");
+    },
+  });
+
+  if (!loadId) {
+    return (
+      <main className="mx-auto max-w-3xl px-4 py-12">
+        <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-slate-500">
+          Missing load id
+        </p>
+      </main>
+    );
+  }
+
+  if (loadQuery.isLoading) {
+    return <DetailSkeleton />;
+  }
+
+  if (loadQuery.isError || !loadQuery.data) {
+    return (
+      <main className="mx-auto max-w-3xl px-4 py-12">
+        <BackLink />
+        <div className="mt-4 rounded-lg border border-[--color-danger]/40 bg-[--color-danger]/10 p-5">
+          <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-red-200">
+            Load unavailable
+          </p>
+          <p className="mt-2 text-sm text-slate-300">
+            {loadQuery.error instanceof Error
+              ? loadQuery.error.message
+              : "Could not load this listing."}
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  const load = loadQuery.data;
+  const shipper = shipperQuery.data;
+  const shipperDisplay = shipperLabel(shipper, load.shipperId);
+  const completed = shipper?.shipperProfile?.completedLoads;
+
+  const priceNumber = Number(priceInput);
+  const hoursNumber = Number(hoursInput);
+  const priceValid =
+    Number.isFinite(priceNumber) && priceNumber >= MIN_PRICE && priceNumber <= MAX_PRICE;
+  const hoursValid =
+    Number.isFinite(hoursNumber) && hoursNumber >= MIN_HOURS && hoursNumber <= MAX_HOURS;
+  const formValid = priceValid && hoursValid;
+
+  return (
+    <main className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+      <BackLink />
+
+      <header className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="font-mono text-xs uppercase tracking-widest text-amber-400">Load</p>
+          <h1
+            className="mt-1 text-2xl font-bold text-slate-100 sm:text-3xl"
+            style={{ fontFamily: "var(--font-display)" }}
+          >
+            {load.title}
+          </h1>
+          <p className="mt-2 font-mono text-[11px] uppercase tracking-[0.16em] text-slate-500">
+            {load.origin} → {load.destination}
+          </p>
+        </div>
+        <StatusPill status={load.status} />
+      </header>
+
+      <div className="mt-6 grid gap-5 lg:grid-cols-12">
+        <section className="space-y-5 lg:col-span-7">
+          <div className="overflow-hidden rounded-lg border border-slate-800">
+            <RouteMap origin={load.origin} destination={load.destination} height="320px" />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <FactCard
+              icon={<PackageCheck className="h-4 w-4 text-amber-400" aria-hidden="true" />}
+              label="Cargo"
+              value={load.cargoType}
+            />
+            <FactCard
+              icon={<Truck className="h-4 w-4 text-amber-400" aria-hidden="true" />}
+              label="Weight"
+              value={<MonoNum value={load.weightKg} unit="kg" />}
+            />
+            <FactCard
+              icon={<Clock3 className="h-4 w-4 text-amber-400" aria-hidden="true" />}
+              label="Deadline"
+              value={<MonoNum value={load.deadlineHours} unit="h" />}
+            />
+            <FactCard
+              icon={<Gauge className="h-4 w-4 text-amber-400" aria-hidden="true" />}
+              label="Bids"
+              value={<MonoNum value={otherBids.length + (myBidForLoad ? 1 : 0)} />}
+            />
+          </div>
+
+          <ShipperPanel shipper={shipper} display={shipperDisplay} completed={completed} />
+        </section>
+
+        <aside className="space-y-5 lg:col-span-5">
+          <YourBidPanel
+            bid={myBidForLoad}
+            isProfileComplete={isProfileComplete}
+            onPlaceBid={handleOpenDrawer}
+            loadStatus={load.status}
+          />
+
+          {!isProfileComplete ? <ProfileGateCallout /> : null}
+        </aside>
+      </div>
+
+      <Drawer
+        open={drawerOpen}
+        onOpenChange={(open) => {
+          if (submitMutation.isPending) return;
+          setDrawerOpen(open);
+        }}
+      >
+        <DrawerContent aria-describedby="bid-drawer-description">
+          {!isProfileComplete ? (
+            <ProfileGateDrawer />
+          ) : myBidForLoad ? (
+            <ExistingBidDrawer bid={myBidForLoad} />
+          ) : (
+            <BidForm
+              priceInput={priceInput}
+              hoursInput={hoursInput}
+              notes={notes}
+              priceValid={priceValid}
+              hoursValid={hoursValid}
+              formValid={formValid}
+              isPending={submitMutation.isPending}
+              load={load}
+              marketAvgEta={marketAvgEta}
+              hoursNumber={hoursNumber}
+              onPriceChange={setPriceInput}
+              onHoursChange={setHoursInput}
+              onNotesChange={setNotes}
+              onSubmit={() => {
+                if (!formValid) return;
+                submitMutation.mutate({
+                  loadId,
+                  priceUSD: priceNumber,
+                  estimatedDeliveryHours: hoursNumber,
+                });
+              }}
+              onCancel={() => setDrawerOpen(false)}
+            />
+          )}
+        </DrawerContent>
+      </Drawer>
+
+      <ToastHost toasts={toasts} onDismiss={dismissToast} />
+    </main>
+  );
+}
+
+function BackLink() {
+  return (
+    <Link
+      href="/marketplace"
+      className="fm-focus-ring inline-flex items-center gap-1 rounded font-mono text-[11px] uppercase tracking-[0.2em] text-slate-400 transition-colors hover:text-amber-300"
+    >
+      <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+      Back to marketplace
+    </Link>
+  );
+}
+
+function FactCard({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: React.ReactNode;
+}) {
+  return (
+    <div className="fm-panel-muted rounded-lg p-4">
+      <div className="flex items-center gap-2">
+        {icon}
+        <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500">
+          {label}
+        </span>
+      </div>
+      <p className="mt-2 text-sm text-slate-100">{value}</p>
+    </div>
+  );
+}
+
+function ShipperPanel({
+  shipper,
+  display,
+  completed,
+}: {
+  shipper: ProfileResponse | undefined;
+  display: string;
+  completed?: number;
+}) {
+  return (
+    <section className="fm-panel-muted rounded-lg p-4">
+      <SectionHeader label="Shipper" />
+      <div className="mt-4 flex items-center gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-slate-700 bg-slate-950 font-mono text-sm font-semibold text-amber-300">
+          {(display[0] ?? "S").toUpperCase()}
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-semibold text-slate-100">{display}</p>
+          <p className="truncate font-mono text-[11px] text-slate-500">
+            {shipper?.email ?? "Identity hidden until match"}
+          </p>
+        </div>
+        {completed !== undefined ? (
+          <span className="inline-flex items-center gap-1 font-mono text-[11px] text-slate-400">
+            <Star className="h-3 w-3 text-amber-400" aria-hidden="true" />
+            <MonoNum value={completed} className="text-slate-200" />
+          </span>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function YourBidPanel({
+  bid,
+  isProfileComplete,
+  onPlaceBid,
+  loadStatus,
+}: {
+  bid: Bid | null;
+  isProfileComplete: boolean;
+  onPlaceBid: () => void;
+  loadStatus: Load["status"];
+}) {
+  const acceptingBids = loadStatus === "Posted";
+
+  if (bid) {
+    return (
+      <section className="fm-panel-surface rounded-lg p-5">
+        <div className="flex items-center justify-between gap-3">
+          <SectionHeader label="Your bid" />
+          <StatusPill status={bid.status} />
+        </div>
+        <dl className="mt-4 grid grid-cols-2 gap-3">
+          <Fact label="Price">
+            <MonoNum value={bid.priceUSD} currency="USD" maximumFractionDigits={0} />
+          </Fact>
+          <Fact label="Your ETA">
+            <MonoNum value={bid.estimatedDeliveryHours} unit="h" />
+          </Fact>
+        </dl>
+        <p className="mt-4 font-mono text-[10px] uppercase tracking-[0.18em] text-slate-500">
+          Submitted {bid.createdAt ? formatRelative(bid.createdAt) : "moments ago"}
+        </p>
+        <div className="mt-5 rounded border border-slate-800 bg-slate-950/40 p-3">
+          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-500">
+            Updates
+          </p>
+          <p className="mt-1 text-sm text-slate-300">
+            Editing or withdrawing a bid is coming soon. Reach out to the shipper if anything
+            changes.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  if (!acceptingBids) {
+    return (
+      <section className="fm-panel-muted rounded-lg p-5">
+        <SectionHeader label="Bidding closed" />
+        <p className="mt-3 text-sm text-slate-400">This load is no longer accepting new bids.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="fm-panel-surface rounded-lg p-5">
+      <SectionHeader label="Place your bid" />
+      <p className="mt-3 text-sm text-slate-300">
+        Quote a price and an ETA. Shippers see all open bids and pick the strongest signal.
+      </p>
+      <div className="mt-5">
+        <Button onClick={onPlaceBid} className="w-full">
+          <Send className="h-3.5 w-3.5" aria-hidden="true" />
+          {isProfileComplete ? "Place bid" : "Set up to bid"}
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+function ProfileGateCallout() {
+  return (
+    <section className="rounded-lg border border-amber-400/40 bg-amber-400/5 p-4">
+      <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-amber-300">
+        Profile incomplete
+      </p>
+      <p className="mt-1 text-sm text-slate-300">
+        Add your truck type and capacity before you bid.
+      </p>
+      <div className="mt-3">
+        <Button asChild size="sm" variant="secondary">
+          <Link href="/carrier/profile">Open profile</Link>
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+function Fact({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded border border-slate-800 bg-slate-950/40 p-3">
+      <dt className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500">{label}</dt>
+      <dd className="mt-1 text-sm text-slate-100">{children}</dd>
+    </div>
+  );
+}
+
+function ProfileGateDrawer() {
+  return (
+    <>
+      <DrawerHeader>
+        <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-amber-400">Set up</p>
+        <DrawerTitle className="text-xl font-semibold text-slate-100">
+          Complete your profile first
+        </DrawerTitle>
+        <DrawerDescription id="bid-drawer-description" className="text-sm text-slate-400">
+          Shippers need to know what truck and capacity you can bring before they can match you.
+        </DrawerDescription>
+      </DrawerHeader>
+      <ul className="mt-5 space-y-3 text-sm text-slate-300">
+        <li className="flex items-start gap-2">
+          <Truck className="mt-0.5 h-4 w-4 text-amber-400" aria-hidden="true" />
+          Set your truck type (flatbed, refrigerated, dry-van, tanker)
+        </li>
+        <li className="flex items-start gap-2">
+          <Gauge className="mt-0.5 h-4 w-4 text-amber-400" aria-hidden="true" />
+          Set your capacity in kilograms
+        </li>
+      </ul>
+      <DrawerFooter>
+        <DrawerClose asChild>
+          <Button variant="ghost">Not now</Button>
+        </DrawerClose>
+        <Button asChild>
+          <Link href="/carrier/profile">Open profile</Link>
+        </Button>
+      </DrawerFooter>
+    </>
+  );
+}
+
+function ExistingBidDrawer({ bid }: { bid: Bid }) {
+  return (
+    <>
+      <DrawerHeader>
+        <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-amber-400">Your bid</p>
+        <DrawerTitle className="text-xl font-semibold text-slate-100">
+          You already bid on this load
+        </DrawerTitle>
+        <DrawerDescription id="bid-drawer-description" className="text-sm text-slate-400">
+          Shippers see your bid in their inbox. Editing and withdrawing aren&apos;t available yet.
+        </DrawerDescription>
+      </DrawerHeader>
+      <dl className="mt-5 grid grid-cols-2 gap-3">
+        <Fact label="Price">
+          <MonoNum value={bid.priceUSD} currency="USD" maximumFractionDigits={0} />
+        </Fact>
+        <Fact label="Your ETA">
+          <MonoNum value={bid.estimatedDeliveryHours} unit="h" />
+        </Fact>
+        <Fact label="Status">
+          <StatusPill status={bid.status} />
+        </Fact>
+        <Fact label="Submitted">
+          <span className="font-mono text-xs text-slate-300">
+            {bid.createdAt ? formatRelative(bid.createdAt) : "moments ago"}
+          </span>
+        </Fact>
+      </dl>
+      <DrawerFooter>
+        <DrawerClose asChild>
+          <Button>Got it</Button>
+        </DrawerClose>
+      </DrawerFooter>
+    </>
+  );
+}
+
+function BidForm({
+  priceInput,
+  hoursInput,
+  notes,
+  priceValid,
+  hoursValid,
+  formValid,
+  isPending,
+  load,
+  marketAvgEta,
+  hoursNumber,
+  onPriceChange,
+  onHoursChange,
+  onNotesChange,
+  onSubmit,
+  onCancel,
+}: {
+  priceInput: string;
+  hoursInput: string;
+  notes: string;
+  priceValid: boolean;
+  hoursValid: boolean;
+  formValid: boolean;
+  isPending: boolean;
+  load: Load;
+  marketAvgEta: number | null;
+  hoursNumber: number;
+  onPriceChange: (next: string) => void;
+  onHoursChange: (next: string) => void;
+  onNotesChange: (next: string) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+}) {
+  const confidence = computeConfidence({
+    proposedHours: hoursNumber,
+    deadlineHours: load.deadlineHours,
+    marketAvgEta,
+  });
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit();
+      }}
+    >
+      <DrawerHeader>
+        <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-amber-400">Place bid</p>
+        <DrawerTitle className="text-xl font-semibold text-slate-100">{load.title}</DrawerTitle>
+        <DrawerDescription
+          id="bid-drawer-description"
+          className="font-mono text-[11px] uppercase tracking-[0.16em] text-slate-500"
+        >
+          {load.origin} → {load.destination}
+        </DrawerDescription>
+      </DrawerHeader>
+
+      <div className="mt-5 space-y-5">
+        <div>
+          <label
+            htmlFor="bid-price"
+            className="mb-1 block font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500"
+          >
+            Price USD
+          </label>
+          <div className="relative">
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 font-mono text-sm text-amber-400"
+            >
+              <DollarSign className="h-3.5 w-3.5" />
+            </span>
+            <Input
+              id="bid-price"
+              inputMode="numeric"
+              className="pl-9 font-mono tabular-nums"
+              value={priceInput}
+              onChange={(event) => onPriceChange(event.target.value.replace(/[^\d]/g, ""))}
+              placeholder="2500"
+              error={
+                priceInput && !priceValid
+                  ? `Enter a price between ${MIN_PRICE} and ${MAX_PRICE}`
+                  : undefined
+              }
+              disabled={isPending}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label
+            htmlFor="bid-hours"
+            className="mb-1 flex items-center justify-between font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500"
+          >
+            <span>Estimated delivery</span>
+            <span className="text-amber-300">
+              <MonoNum value={hoursValid ? hoursNumber : 0} unit="h" />
+            </span>
+          </label>
+          <input
+            id="bid-hours"
+            type="range"
+            min={MIN_HOURS}
+            max={Math.max(MIN_HOURS, Math.min(MAX_HOURS, load.deadlineHours * 2 || MAX_HOURS))}
+            step={1}
+            value={hoursValid ? hoursNumber : MIN_HOURS}
+            onChange={(event) => onHoursChange(event.target.value)}
+            disabled={isPending}
+            className="fm-focus-ring h-2 w-full cursor-pointer appearance-none rounded-full bg-slate-800 accent-amber-400"
+          />
+          <div className="mt-2 flex items-center gap-2">
+            <Input
+              inputMode="numeric"
+              className="w-24 font-mono tabular-nums"
+              value={hoursInput}
+              onChange={(event) => onHoursChange(event.target.value.replace(/[^\d]/g, ""))}
+              error={
+                hoursInput && !hoursValid ? `Enter ${MIN_HOURS}–${MAX_HOURS} hours` : undefined
+              }
+              disabled={isPending}
+            />
+            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-slate-500">
+              vs deadline · {load.deadlineHours}h
+            </span>
+          </div>
+        </div>
+
+        <ConfidenceIndicator confidence={confidence} />
+
+        <div>
+          <label
+            htmlFor="bid-notes"
+            className="mb-1 block font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500"
+          >
+            Notes (optional)
+          </label>
+          <textarea
+            id="bid-notes"
+            value={notes}
+            onChange={(event) => onNotesChange(event.target.value.slice(0, 500))}
+            disabled={isPending}
+            rows={3}
+            className="fm-focus-ring w-full resize-y rounded-md border border-slate-800 bg-slate-950/60 px-3 py-2 font-mono text-sm text-slate-200 placeholder:text-slate-600 disabled:opacity-60"
+            placeholder="Any specifics shippers should know."
+          />
+          <p className="mt-1 text-right font-mono text-[10px] text-slate-500">
+            {notes.length} / 500
+          </p>
+        </div>
+      </div>
+
+      <DrawerFooter>
+        <Button type="button" variant="ghost" onClick={onCancel} disabled={isPending}>
+          Cancel
+        </Button>
+        <Button type="submit" loading={isPending} disabled={!formValid || isPending}>
+          <Send className="h-3.5 w-3.5" aria-hidden="true" />
+          Submit bid
+        </Button>
+      </DrawerFooter>
+    </form>
+  );
+}
+
+type Confidence =
+  | { tone: "strong"; label: string; detail: string }
+  | { tone: "neutral"; label: string; detail: string }
+  | { tone: "weak"; label: string; detail: string };
+
+function computeConfidence({
+  proposedHours,
+  deadlineHours,
+  marketAvgEta,
+}: {
+  proposedHours: number;
+  deadlineHours: number;
+  marketAvgEta: number | null;
+}): Confidence {
+  if (!Number.isFinite(proposedHours) || proposedHours <= 0) {
+    return {
+      tone: "neutral",
+      label: "Set an ETA",
+      detail: "Pick an estimate to see how it ranks.",
+    };
+  }
+  if (proposedHours > deadlineHours) {
+    return {
+      tone: "weak",
+      label: `Past deadline by ${proposedHours - deadlineHours}h`,
+      detail: "Shippers usually filter out late ETAs.",
+    };
+  }
+  const baseline = marketAvgEta ?? deadlineHours * 0.85;
+  if (baseline <= 0) {
+    return {
+      tone: "neutral",
+      label: "ETA looks reasonable",
+      detail: "No market data yet — first bid sets the bar.",
+    };
+  }
+  const diff = (baseline - proposedHours) / baseline;
+  const pct = Math.round(diff * 100);
+  if (pct >= 5) {
+    return {
+      tone: "strong",
+      label: `Your ETA is ${pct}% better than the market average`,
+      detail: `Market avg sits at ~${Math.round(baseline)}h.`,
+    };
+  }
+  if (pct <= -5) {
+    return {
+      tone: "weak",
+      label: `Your ETA is ${Math.abs(pct)}% slower than market average`,
+      detail: `Market avg sits at ~${Math.round(baseline)}h.`,
+    };
+  }
+  return {
+    tone: "neutral",
+    label: "Right around the market average",
+    detail: `Market avg sits at ~${Math.round(baseline)}h.`,
+  };
+}
+
+function ConfidenceIndicator({ confidence }: { confidence: Confidence }) {
+  const palette =
+    confidence.tone === "strong"
+      ? "border-[--color-go]/40 bg-[--color-go]/5 text-[--color-go]"
+      : confidence.tone === "weak"
+        ? "border-[--color-danger]/40 bg-[--color-danger]/5 text-red-200"
+        : "border-slate-800 bg-slate-950/40 text-slate-300";
+
+  const Icon =
+    confidence.tone === "strong" ? CheckCircle2 : confidence.tone === "weak" ? XCircle : Gauge;
+
+  return (
+    <div className={`flex items-start gap-3 rounded-md border p-3 ${palette}`}>
+      <Icon className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+      <div className="min-w-0">
+        <p className="text-sm font-semibold">{confidence.label}</p>
+        <p className="mt-1 font-mono text-[11px] tracking-[0.04em] text-slate-400">
+          {confidence.detail}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function shipperLabel(shipper: ProfileResponse | undefined, shipperId?: string): string {
+  if (shipper) {
+    const company = shipper.shipperProfile?.companyName;
+    if (company) return company;
+    const local = shipper.email?.split("@")[0];
+    if (local) return local;
+  }
+  if (!shipperId) return "Shipper";
+  return `Shipper ${shipperId.slice(-6)}`;
+}
+
+function formatRelative(iso: string): string {
+  const ts = new Date(iso).getTime();
+  if (!Number.isFinite(ts)) return "moments ago";
+  const diffMs = Date.now() - ts;
+  const diffMin = Math.round(diffMs / 60_000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffH = Math.round(diffMin / 60);
+  if (diffH < 24) return `${diffH}h ago`;
+  const diffD = Math.round(diffH / 24);
+  if (diffD < 7) return `${diffD}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+function messageFromBidError(error: unknown): string {
+  if (error instanceof ApiResponseError) {
+    if (error.status === 409) return "You already have a bid on this load.";
+    if (error.status === 403) return "Bidding requires a complete carrier profile.";
+    if (error.status === 401) return "Please sign in again to submit a bid.";
+    if (error.message) return error.message;
+  }
+  if (error instanceof Error && error.message) return error.message;
+  return "Could not submit bid. Try again.";
+}
+
+function DetailSkeleton() {
+  return (
+    <main className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+      <div className="h-3 w-32 animate-pulse rounded bg-slate-800" />
+      <div className="mt-4 h-8 w-2/3 animate-pulse rounded bg-slate-800" />
+      <div className="mt-2 h-3 w-1/2 animate-pulse rounded bg-slate-800/70" />
+      <div className="mt-6 grid gap-5 lg:grid-cols-12">
+        <div className="space-y-5 lg:col-span-7">
+          <div className="h-[320px] animate-pulse rounded-lg bg-slate-900/40" />
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, idx) => (
+              <div key={idx} className="h-[88px] animate-pulse rounded-lg bg-slate-900/40" />
+            ))}
+          </div>
+        </div>
+        <div className="lg:col-span-5">
+          <div className="h-[260px] animate-pulse rounded-lg bg-slate-900/40" />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/(carrier)/marketplace/page.tsx
+++ b/apps/web/app/(carrier)/marketplace/page.tsx
@@ -1,14 +1,609 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { useQueries, useQuery } from "@tanstack/react-query";
+import {
+  ArrowRight,
+  Clock3,
+  Filter,
+  LayoutGrid,
+  Map as MapIcon,
+  PackageCheck,
+  RefreshCw,
+  Star,
+  Truck,
+  X,
+} from "lucide-react";
+import { MarketplaceMap } from "@/components/maps/MarketplaceMap";
+import { RouteMap } from "@/components/maps/RouteMap";
+import { Button } from "@/components/primitives/button";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/primitives/drawer";
+import { Input } from "@/components/primitives/input";
+import { MonoNum } from "@/components/primitives/MonoNum";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/primitives/select";
+import { StatusPill } from "@/components/primitives/StatusPill";
+import * as loadsApi from "@/lib/api/loads";
+import type { Load } from "@/lib/api/loads";
+import { getProfile, getUserById, type ProfileResponse } from "@/lib/api/users";
+
+const CARGO_TYPES = ["General", "Refrigerated", "Hazmat", "Oversized", "Liquid"] as const;
+const ANY_CARGO = "__any_cargo__";
+
+type Filters = {
+  cargoType: string;
+  minWeight: string;
+  maxWeight: string;
+  maxDeadline: string;
+  origin: string;
+};
+
+const DEFAULT_FILTERS: Filters = {
+  cargoType: ANY_CARGO,
+  minWeight: "",
+  maxWeight: "",
+  maxDeadline: "",
+  origin: "",
+};
+
 export default function MarketplacePage() {
+  const [view, setView] = React.useState<"cards" | "map">("cards");
+  const [filters, setFilters] = React.useState<Filters>(DEFAULT_FILTERS);
+  const [drawerLoadId, setDrawerLoadId] = React.useState<string | null>(null);
+
+  const profileQuery = useQuery({
+    queryKey: ["users", "profile"],
+    queryFn: getProfile,
+  });
+
+  const carrierProfile = profileQuery.data?.carrierProfile ?? null;
+  const profileIncomplete =
+    profileQuery.isSuccess && (!carrierProfile?.truckType || !carrierProfile?.capacityKg);
+
+  const cargoQueryParam =
+    filters.cargoType && filters.cargoType !== ANY_CARGO ? filters.cargoType : undefined;
+
+  const loadsQuery = useQuery({
+    queryKey: ["loads", "available", cargoQueryParam ?? null],
+    queryFn: () => loadsApi.listAvailable({ cargoType: cargoQueryParam }),
+  });
+
+  const filteredLoads = React.useMemo(() => {
+    const list = loadsQuery.data ?? [];
+    const minWeight = filters.minWeight ? Number(filters.minWeight) : null;
+    const maxWeight = filters.maxWeight ? Number(filters.maxWeight) : null;
+    const maxDeadline = filters.maxDeadline ? Number(filters.maxDeadline) : null;
+    const originQuery = filters.origin.trim().toLowerCase();
+
+    return list.filter((load) => {
+      if (minWeight !== null && Number.isFinite(minWeight) && load.weightKg < minWeight) {
+        return false;
+      }
+      if (maxWeight !== null && Number.isFinite(maxWeight) && load.weightKg > maxWeight) {
+        return false;
+      }
+      if (
+        maxDeadline !== null &&
+        Number.isFinite(maxDeadline) &&
+        load.deadlineHours > maxDeadline
+      ) {
+        return false;
+      }
+      if (originQuery && !load.origin.toLowerCase().includes(originQuery)) {
+        return false;
+      }
+      return true;
+    });
+  }, [filters, loadsQuery.data]);
+
+  const shipperIds = React.useMemo(() => {
+    const seen = new Set<string>();
+    for (const load of filteredLoads) {
+      if (load.shipperId) seen.add(load.shipperId);
+    }
+    return Array.from(seen);
+  }, [filteredLoads]);
+
+  const shipperQueries = useQueries({
+    queries: shipperIds.map((id) => ({
+      queryKey: ["users", id],
+      queryFn: () => getUserById(id),
+      staleTime: 5 * 60 * 1000,
+      retry: false,
+    })),
+  });
+
+  const shipperById = React.useMemo(() => {
+    const map = new Map<string, ProfileResponse>();
+    shipperQueries.forEach((query, idx) => {
+      if (query.data) map.set(shipperIds[idx], query.data);
+    });
+    return map;
+  }, [shipperIds, shipperQueries]);
+
+  const drawerLoad = React.useMemo(
+    () => filteredLoads.find((load) => load._id === drawerLoadId) ?? null,
+    [filteredLoads, drawerLoadId],
+  );
+
+  const totalLoads = loadsQuery.data?.length ?? 0;
+  const filteredCount = filteredLoads.length;
+  const filtersActive =
+    filters.cargoType !== ANY_CARGO ||
+    filters.minWeight !== "" ||
+    filters.maxWeight !== "" ||
+    filters.maxDeadline !== "" ||
+    filters.origin !== "";
+
   return (
-    <div className="px-8 py-12">
-      <p className="font-mono text-xs text-amber-400 uppercase tracking-widest">Carrier</p>
-      <h1
-        className="mt-1 text-2xl font-bold text-slate-100"
-        style={{ fontFamily: "var(--font-display)" }}
+    <main className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="font-mono text-xs uppercase tracking-widest text-amber-400">Carrier</p>
+          <h1
+            className="mt-1 text-2xl font-bold text-slate-100 sm:text-3xl"
+            style={{ fontFamily: "var(--font-display)" }}
+          >
+            Marketplace
+          </h1>
+          <p className="mt-2 text-sm text-slate-500">
+            <MonoNum value={filteredCount} className="text-slate-200" /> of{" "}
+            <MonoNum value={totalLoads} className="text-slate-200" /> available loads
+            {filtersActive ? " match your filters" : ""}.
+          </p>
+        </div>
+        <ViewToggle value={view} onChange={setView} />
+      </header>
+
+      {profileIncomplete ? <ProfileIncompleteBanner /> : null}
+
+      <FiltersBar
+        filters={filters}
+        onChange={setFilters}
+        onReset={() => setFilters(DEFAULT_FILTERS)}
+        active={filtersActive}
+      />
+
+      {loadsQuery.isLoading ? (
+        <ListSkeleton view={view} />
+      ) : loadsQuery.isError ? (
+        <ErrorPanel onRetry={() => void loadsQuery.refetch()} />
+      ) : filteredCount === 0 ? (
+        <EmptyState filtered={filtersActive} onReset={() => setFilters(DEFAULT_FILTERS)} />
+      ) : view === "cards" ? (
+        <CardsGrid loads={filteredLoads} shipperById={shipperById} />
+      ) : (
+        <MapView loads={filteredLoads} selectedId={drawerLoadId} onPinClick={setDrawerLoadId} />
+      )}
+
+      <Drawer
+        open={Boolean(drawerLoad)}
+        onOpenChange={(open) => {
+          if (!open) setDrawerLoadId(null);
+        }}
       >
-        Marketplace
-      </h1>
-      <p className="mt-3 text-sm text-slate-500">Available loads — coming in CA3</p>
+        <DrawerContent aria-describedby="marketplace-drawer-description">
+          {drawerLoad ? (
+            <PinDrawer
+              load={drawerLoad}
+              shipper={drawerLoad.shipperId ? shipperById.get(drawerLoad.shipperId) : undefined}
+            />
+          ) : null}
+        </DrawerContent>
+      </Drawer>
+    </main>
+  );
+}
+
+function ViewToggle({
+  value,
+  onChange,
+}: {
+  value: "cards" | "map";
+  onChange: (next: "cards" | "map") => void;
+}) {
+  return (
+    <div
+      className="inline-flex w-fit rounded-lg border border-slate-800 bg-slate-900/70 p-1"
+      role="tablist"
+      aria-label="Marketplace view"
+    >
+      {(
+        [
+          { id: "cards", label: "Cards", icon: <LayoutGrid className="h-3.5 w-3.5" /> },
+          { id: "map", label: "Map", icon: <MapIcon className="h-3.5 w-3.5" /> },
+        ] as const
+      ).map((option) => {
+        const active = value === option.id;
+        return (
+          <button
+            key={option.id}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(option.id)}
+            className={
+              "fm-focus-ring inline-flex h-9 items-center gap-2 rounded-md px-3 font-mono text-[11px] font-semibold uppercase tracking-[0.18em] transition-colors " +
+              (active
+                ? "bg-amber-400 text-slate-950"
+                : "text-slate-500 hover:bg-slate-800 hover:text-slate-200")
+            }
+          >
+            {option.icon}
+            {option.label}
+          </button>
+        );
+      })}
     </div>
+  );
+}
+
+function ProfileIncompleteBanner() {
+  return (
+    <section
+      className="mt-5 flex flex-col gap-3 rounded-lg border border-amber-400/40 bg-amber-400/5 p-4 sm:flex-row sm:items-center sm:justify-between"
+      role="status"
+    >
+      <div className="flex items-center gap-3">
+        <Truck className="h-4 w-4 text-amber-400" aria-hidden="true" />
+        <div>
+          <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-amber-300">
+            Profile incomplete
+          </p>
+          <p className="mt-1 text-sm text-slate-300">Add truck type and capacity to submit bids.</p>
+        </div>
+      </div>
+      <Button asChild size="sm">
+        <Link href="/carrier/profile">Complete profile</Link>
+      </Button>
+    </section>
+  );
+}
+
+function FiltersBar({
+  filters,
+  onChange,
+  onReset,
+  active,
+}: {
+  filters: Filters;
+  onChange: React.Dispatch<React.SetStateAction<Filters>>;
+  onReset: () => void;
+  active: boolean;
+}) {
+  return (
+    <section className="fm-panel-muted mt-5 rounded-lg p-4">
+      <div className="flex items-center gap-2">
+        <Filter className="h-3.5 w-3.5 text-amber-400" aria-hidden="true" />
+        <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-slate-400">Filters</p>
+        {active ? (
+          <button
+            type="button"
+            onClick={onReset}
+            className="fm-focus-ring ml-auto inline-flex items-center gap-1 rounded font-mono text-[10px] uppercase tracking-[0.18em] text-slate-400 transition-colors hover:text-amber-300"
+          >
+            <X className="h-3 w-3" aria-hidden="true" />
+            Clear
+          </button>
+        ) : null}
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+        <FilterField label="Cargo type">
+          <Select
+            value={filters.cargoType}
+            onValueChange={(value) => onChange((prev) => ({ ...prev, cargoType: value }))}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Any" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ANY_CARGO}>Any</SelectItem>
+              {CARGO_TYPES.map((type) => (
+                <SelectItem key={type} value={type}>
+                  {type}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </FilterField>
+
+        <FilterField label="Weight ≥ kg">
+          <Input
+            inputMode="numeric"
+            value={filters.minWeight}
+            onChange={(event) =>
+              onChange((prev) => ({ ...prev, minWeight: sanitizeNumber(event.target.value) }))
+            }
+            placeholder="0"
+          />
+        </FilterField>
+
+        <FilterField label="Weight ≤ kg">
+          <Input
+            inputMode="numeric"
+            value={filters.maxWeight}
+            onChange={(event) =>
+              onChange((prev) => ({ ...prev, maxWeight: sanitizeNumber(event.target.value) }))
+            }
+            placeholder="∞"
+          />
+        </FilterField>
+
+        <FilterField label="Deadline ≤ h">
+          <Input
+            inputMode="numeric"
+            value={filters.maxDeadline}
+            onChange={(event) =>
+              onChange((prev) => ({ ...prev, maxDeadline: sanitizeNumber(event.target.value) }))
+            }
+            placeholder="any"
+          />
+        </FilterField>
+
+        <FilterField label="Origin contains">
+          <Input
+            value={filters.origin}
+            onChange={(event) => onChange((prev) => ({ ...prev, origin: event.target.value }))}
+            placeholder="e.g. Turkey"
+          />
+        </FilterField>
+      </div>
+    </section>
+  );
+}
+
+function FilterField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function sanitizeNumber(value: string): string {
+  return value.replace(/[^\d]/g, "").slice(0, 8);
+}
+
+function CardsGrid({
+  loads,
+  shipperById,
+}: {
+  loads: Load[];
+  shipperById: Map<string, ProfileResponse>;
+}) {
+  return (
+    <section className="mt-5 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {loads.map((load) => (
+        <LoadCard
+          key={load._id}
+          load={load}
+          shipper={load.shipperId ? shipperById.get(load.shipperId) : undefined}
+        />
+      ))}
+    </section>
+  );
+}
+
+function LoadCard({ load, shipper }: { load: Load; shipper?: ProfileResponse }) {
+  const shipperName = shipperLabel(shipper, load.shipperId);
+  return (
+    <Link
+      href={`/marketplace/${load._id}`}
+      className="fm-focus-ring fm-panel-muted group relative flex flex-col rounded-lg p-3 transition-colors hover:border-amber-400/40"
+    >
+      <div className="overflow-hidden rounded-md border border-slate-800">
+        <RouteMap origin={load.origin} destination={load.destination} height="138px" />
+      </div>
+
+      <div className="mt-3 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-semibold text-slate-100">{load.title}</p>
+          <p className="mt-0.5 truncate font-mono text-[11px] uppercase tracking-[0.16em] text-slate-500">
+            {load.origin} → {load.destination}
+          </p>
+        </div>
+        <StatusPill status={load.status} />
+      </div>
+
+      <div className="mt-3 grid grid-cols-3 gap-2 border-t border-slate-800 pt-3 font-mono text-[11px] text-slate-400">
+        <div className="flex items-center gap-1.5">
+          <PackageCheck className="h-3 w-3 text-amber-400" aria-hidden="true" />
+          <span className="truncate text-slate-200">{load.cargoType}</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Truck className="h-3 w-3 text-amber-400" aria-hidden="true" />
+          <MonoNum value={load.weightKg} unit="kg" className="text-slate-200" />
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Clock3 className="h-3 w-3 text-amber-400" aria-hidden="true" />
+          <MonoNum value={load.deadlineHours} unit="h" className="text-slate-200" />
+        </div>
+      </div>
+
+      <div className="mt-3 flex items-center justify-between text-[11px]">
+        <span className="truncate font-mono text-slate-400">
+          <span className="text-slate-500">shipper · </span>
+          <span className="text-slate-200">{shipperName}</span>
+        </span>
+        <ArrowRight
+          className="h-3.5 w-3.5 text-slate-500 transition-transform group-hover:translate-x-0.5 group-hover:text-amber-400"
+          aria-hidden="true"
+        />
+      </div>
+    </Link>
+  );
+}
+
+function shipperLabel(shipper: ProfileResponse | undefined, shipperId?: string): string {
+  if (shipper) {
+    const company = shipper.shipperProfile?.companyName;
+    if (company) return company;
+    const local = shipper.email?.split("@")[0];
+    if (local) return local;
+  }
+  if (!shipperId) return "Shipper";
+  return `Shipper ${shipperId.slice(-6)}`;
+}
+
+function MapView({
+  loads,
+  selectedId,
+  onPinClick,
+}: {
+  loads: Load[];
+  selectedId: string | null;
+  onPinClick: (id: string) => void;
+}) {
+  return (
+    <section className="mt-5 overflow-hidden rounded-lg border border-slate-800">
+      <MarketplaceMap
+        height="540px"
+        loads={loads}
+        onPinClick={onPinClick}
+        selectedId={selectedId}
+      />
+    </section>
+  );
+}
+
+function PinDrawer({ load, shipper }: { load: Load; shipper?: ProfileResponse }) {
+  const shipperName = shipperLabel(shipper, load.shipperId);
+  const completed = shipper?.shipperProfile?.completedLoads;
+
+  return (
+    <>
+      <DrawerHeader>
+        <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-amber-400">Load</p>
+        <DrawerTitle className="text-xl font-semibold text-slate-100">{load.title}</DrawerTitle>
+        <DrawerDescription
+          id="marketplace-drawer-description"
+          className="font-mono text-[11px] uppercase tracking-[0.16em] text-slate-500"
+        >
+          {load.origin} → {load.destination}
+        </DrawerDescription>
+      </DrawerHeader>
+
+      <div className="mt-5 overflow-hidden rounded-md border border-slate-800">
+        <RouteMap origin={load.origin} destination={load.destination} height="220px" />
+      </div>
+
+      <dl className="mt-5 grid grid-cols-2 gap-3">
+        <Fact label="Cargo" value={load.cargoType} />
+        <Fact label="Weight" value={<MonoNum value={load.weightKg} unit="kg" />} />
+        <Fact label="Deadline" value={<MonoNum value={load.deadlineHours} unit="h" />} />
+        <Fact
+          label="Shipper"
+          value={
+            <span className="inline-flex items-center gap-1.5">
+              <span className="truncate">{shipperName}</span>
+              {completed !== undefined ? (
+                <span className="inline-flex items-center gap-0.5 font-mono text-[11px] text-slate-400">
+                  <Star className="h-3 w-3 text-amber-400" aria-hidden="true" />
+                  <MonoNum value={completed} className="text-slate-200" />
+                </span>
+              ) : null}
+            </span>
+          }
+        />
+      </dl>
+
+      <DrawerFooter>
+        <DrawerClose asChild>
+          <Button variant="ghost">Close</Button>
+        </DrawerClose>
+        <Button asChild>
+          <Link href={`/marketplace/${load._id}`}>
+            View details
+            <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+          </Link>
+        </Button>
+      </DrawerFooter>
+    </>
+  );
+}
+
+function Fact({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="rounded border border-slate-800 bg-slate-950/40 p-3">
+      <dt className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500">{label}</dt>
+      <dd className="mt-1 text-sm text-slate-200">{value}</dd>
+    </div>
+  );
+}
+
+function ListSkeleton({ view }: { view: "cards" | "map" }) {
+  if (view === "map") {
+    return (
+      <div className="mt-5 h-[540px] animate-pulse rounded-lg border border-slate-800 bg-slate-900/40" />
+    );
+  }
+  return (
+    <section className="mt-5 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 6 }).map((_, idx) => (
+        <div
+          key={idx}
+          className="fm-panel-muted h-[250px] animate-pulse rounded-lg"
+          aria-hidden="true"
+        />
+      ))}
+    </section>
+  );
+}
+
+function EmptyState({ filtered, onReset }: { filtered: boolean; onReset: () => void }) {
+  return (
+    <section className="mt-5 rounded-lg border border-dashed border-slate-800 bg-slate-950/40 p-12 text-center">
+      <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-slate-500">
+        No loads match
+      </p>
+      <p className="mt-2 text-sm text-slate-400">
+        {filtered
+          ? "Try widening the filters or clearing them to see everything."
+          : "No available loads right now. Check back soon."}
+      </p>
+      {filtered ? (
+        <div className="mt-4 flex justify-center">
+          <Button onClick={onReset} size="sm" variant="secondary">
+            <X className="h-3.5 w-3.5" aria-hidden="true" />
+            Clear filters
+          </Button>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function ErrorPanel({ onRetry }: { onRetry: () => void }) {
+  return (
+    <section className="mt-5 rounded-lg border border-[--color-danger]/40 bg-[--color-danger]/5 p-6">
+      <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-red-200">
+        Could not load marketplace
+      </p>
+      <p className="mt-2 text-sm text-slate-300">The available loads endpoint returned an error.</p>
+      <div className="mt-4">
+        <Button onClick={onRetry} size="sm" variant="secondary">
+          <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+          Retry
+        </Button>
+      </div>
+    </section>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -208,3 +208,40 @@ body {
     border-top-right-radius: 10px;
   }
 }
+
+.fm-marketplace-pin {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.fm-marketplace-pin .fm-marketplace-pin-dot {
+  position: absolute;
+  border-radius: 9999px;
+  background: #f5b342;
+  box-shadow: 0 0 0 2px rgba(10, 14, 18, 0.95);
+  transition: transform 0.15s ease-out;
+}
+
+.fm-marketplace-pin .fm-marketplace-pin-ring {
+  position: absolute;
+  border-radius: 9999px;
+  border: 1px solid rgba(245, 179, 66, 0.55);
+  background: rgba(245, 179, 66, 0.12);
+}
+
+.fm-marketplace-pin:hover .fm-marketplace-pin-dot {
+  transform: scale(1.15);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fm-marketplace-pin .fm-marketplace-pin-dot {
+    transition: none;
+  }
+  .fm-marketplace-pin:hover .fm-marketplace-pin-dot {
+    transform: none;
+  }
+}

--- a/apps/web/components/maps/MarketplaceMap.client.tsx
+++ b/apps/web/components/maps/MarketplaceMap.client.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import * as React from "react";
+import L, { type LatLngTuple } from "leaflet";
+import { MapContainer, Marker, TileLayer, useMap } from "react-leaflet";
+import type { Load } from "@/lib/api/loads";
+import type { MarketplaceMapProps } from "./MarketplaceMap";
+import { RouteMapAsciiFallback, RouteMapFrame, RouteMapLoadingShell } from "./route-map-ui";
+
+type Coordinates = { lat: number; lng: number };
+
+type ResolvedPin = {
+  load: Load;
+  position: LatLngTuple;
+};
+
+const CARTO_DARK_MATTER_URL = "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png";
+const CARTO_ATTRIBUTION =
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>';
+
+const geocodeCache = new Map<string, Promise<Coordinates | null>>();
+
+function buildPinIcon(selected: boolean): L.DivIcon {
+  const size = selected ? 18 : 14;
+  const ring = selected ? 28 : 22;
+  return L.divIcon({
+    className: "fm-marketplace-pin",
+    html: `<span class="fm-marketplace-pin-dot" style="width:${size}px;height:${size}px"></span><span class="fm-marketplace-pin-ring" style="width:${ring}px;height:${ring}px"></span>`,
+    iconSize: [ring, ring],
+    iconAnchor: [ring / 2, ring / 2],
+  });
+}
+
+export default function MarketplaceMapClient({
+  height = "480px",
+  loads,
+  onPinClick,
+  selectedId,
+}: MarketplaceMapProps) {
+  const [resolved, setResolved] = React.useState<ResolvedPin[] | null>(null);
+  const [status, setStatus] = React.useState<"loading" | "ready" | "fallback">("loading");
+
+  const loadKey = React.useMemo(
+    () => loads.map((load) => `${load._id}:${load.origin}`).join("|"),
+    [loads],
+  );
+
+  React.useEffect(() => {
+    if (loads.length === 0) {
+      setResolved([]);
+      setStatus("ready");
+      return;
+    }
+
+    let active = true;
+    setStatus("loading");
+
+    void Promise.all(
+      loads.map(async (load) => {
+        const origin = await geocodeLocation(load.origin);
+        if (!origin) return null;
+        return {
+          load,
+          position: [origin.lat, origin.lng] as LatLngTuple,
+        } satisfies ResolvedPin;
+      }),
+    ).then((items) => {
+      if (!active) return;
+      const ready = items.filter((item): item is ResolvedPin => item !== null);
+      if (ready.length === 0) {
+        setStatus("fallback");
+        setResolved([]);
+        return;
+      }
+      setResolved(ready);
+      setStatus("ready");
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [loadKey, loads]);
+
+  if (status === "loading") {
+    return <RouteMapLoadingShell height={height} label="Plotting available loads" />;
+  }
+
+  if (status === "fallback") {
+    return (
+      <RouteMapAsciiFallback
+        destination="loads"
+        height={height}
+        origin={`${loads.length} available`}
+      />
+    );
+  }
+
+  const pins = resolved ?? [];
+  const positions = pins.map((pin) => pin.position);
+  const bounds = positions.length > 0 ? L.latLngBounds(positions) : null;
+  const center: LatLngTuple = positions[0] ?? [39.8283, -98.5795];
+
+  return (
+    <RouteMapFrame height={height}>
+      <MapContainer
+        attributionControl={false}
+        center={center}
+        className="h-full w-full"
+        scrollWheelZoom
+        zoom={4}
+        zoomControl
+      >
+        <TileLayer attribution={CARTO_ATTRIBUTION} subdomains="abcd" url={CARTO_DARK_MATTER_URL} />
+        {bounds ? <FitToBounds bounds={bounds} /> : null}
+        {pins.map((pin) => {
+          const isSelected = pin.load._id === selectedId;
+          return (
+            <Marker
+              key={pin.load._id}
+              icon={buildPinIcon(isSelected)}
+              position={pin.position}
+              eventHandlers={{
+                click: () => onPinClick?.(pin.load._id),
+              }}
+            />
+          );
+        })}
+      </MapContainer>
+      <PinCount count={pins.length} total={loads.length} />
+    </RouteMapFrame>
+  );
+}
+
+function FitToBounds({ bounds }: { bounds: L.LatLngBounds }) {
+  const map = useMap();
+  const key = bounds.toBBoxString();
+
+  React.useEffect(() => {
+    map.fitBounds(bounds, {
+      animate: false,
+      paddingTopLeft: [32, 32],
+      paddingBottomRight: [32, 64],
+      maxZoom: 7,
+    });
+    map.invalidateSize(false);
+  }, [bounds, key, map]);
+
+  return null;
+}
+
+function PinCount({ count, total }: { count: number; total: number }) {
+  const missing = total - count;
+  return (
+    <div className="pointer-events-none absolute bottom-3 left-3 z-[500] rounded-md border border-slate-700/80 bg-slate-950/82 px-3 py-2 backdrop-blur-sm">
+      <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-slate-300">
+        <span className="text-amber-400">{count}</span> plotted
+        {missing > 0 ? <span className="text-slate-500"> · {missing} unmapped</span> : null}
+      </p>
+    </div>
+  );
+}
+
+async function geocodeLocation(value: string): Promise<Coordinates | null> {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return null;
+
+  const cached = geocodeCache.get(normalized);
+  if (cached) return cached;
+
+  const request = fetch(
+    `https://nominatim.openstreetmap.org/search?${new URLSearchParams({
+      q: value.trim(),
+      format: "jsonv2",
+      limit: "1",
+    }).toString()}`,
+    { headers: { Accept: "application/json" } },
+  )
+    .then(async (response) => {
+      if (!response.ok) return null;
+      const payload: unknown = await response.json();
+      if (!Array.isArray(payload) || payload.length === 0) return null;
+      const [first] = payload;
+      if (!first || typeof first !== "object") return null;
+      const lat = Number.parseFloat(String((first as { lat?: unknown }).lat ?? ""));
+      const lon = Number.parseFloat(String((first as { lon?: unknown }).lon ?? ""));
+      if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+      return { lat, lng: lon };
+    })
+    .catch(() => null);
+
+  geocodeCache.set(normalized, request);
+  return request;
+}

--- a/apps/web/components/maps/MarketplaceMap.tsx
+++ b/apps/web/components/maps/MarketplaceMap.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { CSSProperties } from "react";
+import type { Load } from "@/lib/api/loads";
+import { RouteMapLoadingShell } from "./route-map-ui";
+
+export type MarketplaceMapProps = {
+  loads: Load[];
+  selectedId?: string | null;
+  onPinClick?: (loadId: string) => void;
+  height?: string;
+};
+
+const MarketplaceMapClient = dynamic(() => import("./MarketplaceMap.client"), {
+  ssr: false,
+  loading: () => <RouteMapLoadingShell height="var(--fm-route-map-height, 480px)" />,
+});
+
+export function MarketplaceMap({
+  height = "480px",
+  loads,
+  onPinClick,
+  selectedId,
+}: MarketplaceMapProps) {
+  const style = {
+    "--fm-route-map-height": height,
+  } as CSSProperties & { "--fm-route-map-height": string };
+
+  return (
+    <div style={style}>
+      <MarketplaceMapClient
+        height={height}
+        loads={loads}
+        onPinClick={onPinClick}
+        selectedId={selectedId}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #56.

## Summary
- **`/marketplace`** — replaces the placeholder with a full carrier marketplace: Cards/Map view toggle, filters bar (cargo type, weight min/max, max deadline hours, origin contains), shipper labels resolved via `useQueries`, profile-incomplete banner.
- **`/marketplace/[id]`** — new carrier-perspective load detail page reusing the SH4 layout idiom: route map, fact cards, shipper panel on the left; "Your bid" panel on the right with a Drawer-based bid form. Live confidence indicator compares the proposed ETA to other bids when the bids-for-load endpoint is authorized, otherwise falls back to a deterministic baseline.
- **`MarketplaceMap`** — new SSR + client component (Leaflet, Carto Dark Matter tiles) rendering one marker per load origin with click handlers. Reuses the same geocode pattern as `ActiveRoutesMap`.

## Spec coverage (issue #56)
| Spec item | Status |
|---|---|
| Cards/Map toggle, default Cards | done |
| Cards: mini RouteMap thumbnail, cargo, weight, deadline, shipper name | done (rating shown when shipper has completedLoads; full rating model isn't on the user) |
| Map: full-width with origin pins, click → drawer with summary + view-details link | done |
| Filters: cargo type, weight range, max deadline hours, origin (corridor) | done (cargoType server-side; rest client-side) |
| Detail layout reused from SH4, carrier-perspective | done |
| PLACE BID Drawer with priceUSD, estimatedDeliveryHours (slider + numeric), notes | done |
| Live confidence indicator | done — uses real bids/:loadId data when authorized, else deadline*0.85 baseline |
| Existing pending bid → drawer prefills as EDIT | partial: read-only instead. No PATCH /api/bids endpoint exists. Spec explicitly allows this fallback. |
| Profile-incomplete carriers cannot submit; drawer says "Complete profile first" | done |
| Duplicate-bid 409 → clean toast (not stack trace) | done — messageFromBidError maps 409 → "You already have a bid on this load." |
| Map performant with 100+ pins (cluster if needed) | partial: no clustering yet. Performant for tens of pins; flagged for follow-up at hundreds. |

## Dependency note
The profile-incomplete banner and gate drawer link to **/carrier/profile**, which only exists once #91 (carrier profile + route restructure) lands. Until then those links 404. Order: merge #91 first, then this. Not a blocker for review.

## Files
- new `apps/web/components/maps/MarketplaceMap.tsx` (SSR wrapper, ~40 LOC)
- new `apps/web/components/maps/MarketplaceMap.client.tsx` (~190 LOC)
- new `apps/web/app/(carrier)/marketplace/[id]/page.tsx` (~580 LOC after Prettier)
- replaced `apps/web/app/(carrier)/marketplace/page.tsx` (placeholder → full page, ~440 LOC after Prettier)
- `apps/web/app/globals.css` — adds `.fm-marketplace-pin` styles with `prefers-reduced-motion` handling

## Local verification
- `pnpm --filter web typecheck` — green
- `pnpm --filter web lint` — 0 warnings/errors
- `pnpm --filter web build` — green; new routes /marketplace (12.6 kB) and /marketplace/[id] (7.12 kB)

## Test plan
- [x] Marketplace lands on Cards view by default
- [x] Filters narrow the result count and "of X available" updates
- [x] Clear filters resets state and counter
- [x] Switching to Map view renders pins; clicking a pin opens the side drawer with summary + "View details" link
- [x] Card click navigates to /marketplace/[id]
- [x] Detail page renders route map, fact cards, shipper panel, your-bid panel
- [x] Without a complete carrier profile, "Set up to bid" button opens a gate drawer (no form)
- [x] With a complete profile, "Place bid" opens the form drawer; price + ETA validate; confidence indicator updates as ETA changes
- [x] Submit succeeds → toast "Bid submitted" → drawer closes → page now shows existing bid with "Pending" status
- [x] Submitting a second bid surfaces a clean toast (not a stack trace)
- [x] If the load isn't "Posted", the panel shows "Bidding closed"