### PR TITLE
feat(web): a11y/perf polish pass for #62

### DIFF
--- a/apps/web/TESTING.md
+++ b/apps/web/TESTING.md
@@ -1,0 +1,87 @@
+# apps/web — Manual QA Checklist
+
+Smoke checklist for the golden paths shipped under epic [#39](https://github.com/yigitbozyaka/freightmatch/issues/39). Run end-to-end against a clean DB before promoting `master` to a release branch.
+
+## Setup
+
+1. `pnpm dev` from the monorepo root (boots web + user-service + load-service + bid-service + ai-service)
+2. Register two fresh accounts: one `Shipper`, one `Carrier`
+3. Open the shipper in one browser, the carrier in an incognito window
+
+## Golden paths
+
+### 1. Shipper onboarding
+
+- [ ] `/register` rejects mismatched passwords with an inline error
+- [ ] After register, lands on `/shipper/dashboard` (no role-routing flash)
+- [ ] Empty dashboard shows themed "no loads yet" state with CTA to `/shipper/loads/new`
+- [ ] `/shipper/profile`: setting company name, contact name, and phone enables Save; refresh confirms persistence
+- [ ] `/settings`: change password flow validates current password and signs out on success
+
+### 2. Shipper posts a load
+
+- [ ] `/shipper/loads/new` step 1: origin/destination Nominatim search returns results, pins update on selection
+- [ ] Step 2: weight, cargo type, deadline validate (deadline must be future, weight > 0)
+- [ ] Step 3: review screen shows all fields with mono numerics and amber edge
+- [ ] Step 4: submit → toast confirms → redirect to `/shipper/loads/[id]`
+- [ ] Load detail timeline shows `Posted` step active; Bid Inbox shows "No bids yet" empty state
+- [ ] `/shipper/loads` index lists the new load with status chip = `Posted`
+
+### 3. Carrier discovers + bids
+
+- [ ] Sign in as carrier; lands on `/carrier/dashboard`
+- [ ] Profile-incomplete banner appears with link to `/carrier/profile`
+- [ ] Complete carrier profile (truck type, capacity kg) → banner clears
+- [ ] `/marketplace` Cards view shows the shipper's load
+- [ ] Filter by cargo type, min/max weight, max deadline — counts update; empty state shows on no match
+- [ ] Switch to Map view → pin renders at origin; clicking pin opens drawer with summary
+- [ ] Open `/marketplace/[id]` → BidForm visible; price/eta/notes validate; submit succeeds
+- [ ] After submit, `/bids` shows the new bid under "Pending"; load detail's "Your bid" panel shows read-only summary
+
+### 4. Shipper accepts a bid
+
+- [ ] Shipper reloads `/shipper/loads/[id]`; Bid Inbox lists carrier's bid
+- [ ] AI Recommendations panel ranks the bid (or shows "No recommendations" empty)
+- [ ] Click "Accept" → confirmation; load timeline advances to `Booked`; competing bids auto-rejected (if any)
+- [ ] Carrier's `/bids` now shows the bid under "Accepted"
+
+### 5. Status transitions
+
+- [ ] Shipper marks `In Transit` from load detail; timeline + status chips update
+- [ ] Shipper marks `Delivered`; load chip turns green; `/shipper/loads` filter "Delivered" includes it
+- [ ] Reverse direction not possible (UI hides illegal transitions)
+
+### 6. Ask Ops chat
+
+- [ ] `/chat` greets with empty state ("link standby")
+- [ ] Suggested prompts disabled while sending; after response, chat scrolls to bottom
+- [ ] Long markdown response renders with mono code blocks and tables
+
+## Accessibility
+
+- [ ] Tab from URL bar reveals "Skip to main content" — pressing Enter focuses the page main
+- [ ] All form fields announced with label + error via screen reader (VoiceOver / NVDA)
+- [ ] Focus rings visible on amber primary buttons (dark inner ring, amber outer)
+- [ ] All routes pass Axe DevTools with **0 serious/critical** violations
+- [ ] Keyboard-only: open drawers (bid form, profile photo crop, AI recs) with Enter; Escape closes
+- [ ] `prefers-reduced-motion: reduce` neutralizes hero corridor pulses, drawer slides, skeleton pulses
+
+## Performance (Lighthouse — mobile, throttled)
+
+- [ ] `/` landing — Performance ≥ 95
+- [ ] `/shipper/dashboard` — Performance ≥ 90
+- [ ] `/carrier/dashboard` — Performance ≥ 90
+- [ ] `/marketplace` — Performance ≥ 90
+- [ ] CLS < 0.1 on every route above
+
+## Error + edge states
+
+- [ ] `/no-such-route` renders themed 404 with "Return to base"
+- [ ] Throwing an error in any RSC renders themed 500 (`error.tsx`) with Retry + Return to base
+- [ ] Backend down (kill user-service): protected pages show themed error, sign-in shows "Unable to sign in right now"
+- [ ] Network offline: queries surface "Couldn't load" empty states, not blank pages
+
+## Notes
+
+- The `(carrier)`, `(shipper)`, `(shared)`, `(auth)` route groups all share the same Navbar and skip link — verify visually on the auth screens that the skip link is reachable but not visible by default.
+- Status pill flicker is a one-off animation on mount; should not loop.

--- a/apps/web/app/(auth)/_components/auth-shell.tsx
+++ b/apps/web/app/(auth)/_components/auth-shell.tsx
@@ -22,7 +22,11 @@ export function AuthShell({
   footerText,
 }: AuthShellProps) {
   return (
-    <main className="relative flex min-h-dvh items-center justify-center overflow-hidden px-4 py-10 sm:px-6">
+    <main
+      className="relative flex min-h-dvh items-center justify-center overflow-hidden px-4 py-10 sm:px-6"
+      id="main"
+      tabIndex={-1}
+    >
       <div
         aria-hidden="true"
         className="pointer-events-none fixed inset-0 -z-10 opacity-[0.07] mix-blend-screen"

--- a/apps/web/app/(carrier)/layout.tsx
+++ b/apps/web/app/(carrier)/layout.tsx
@@ -4,7 +4,9 @@ export default function CarrierLayout({ children }: { children: React.ReactNode 
   return (
     <div className="min-h-dvh flex flex-col">
       <Navbar />
-      <main className="flex-1">{children}</main>
+      <main className="flex-1" id="main" tabIndex={-1}>
+        {children}
+      </main>
     </div>
   );
 }

--- a/apps/web/app/(shared)/layout.tsx
+++ b/apps/web/app/(shared)/layout.tsx
@@ -4,7 +4,9 @@ export default function SharedLayout({ children }: { children: React.ReactNode }
   return (
     <div className="flex min-h-dvh flex-col">
       <Navbar />
-      <main className="flex-1">{children}</main>
+      <main className="flex-1" id="main" tabIndex={-1}>
+        {children}
+      </main>
     </div>
   );
 }

--- a/apps/web/app/(shipper)/layout.tsx
+++ b/apps/web/app/(shipper)/layout.tsx
@@ -4,7 +4,9 @@ export default function ShipperLayout({ children }: { children: React.ReactNode 
   return (
     <div className="min-h-dvh flex flex-col">
       <Navbar />
-      <main className="flex-1">{children}</main>
+      <main className="flex-1" id="main" tabIndex={-1}>
+        {children}
+      </main>
     </div>
   );
 }

--- a/apps/web/app/403/page.tsx
+++ b/apps/web/app/403/page.tsx
@@ -2,7 +2,11 @@ import Link from "next/link";
 
 export default function ForbiddenPage() {
   return (
-    <main className="flex min-h-dvh flex-col items-center justify-center px-6 text-center">
+    <main
+      className="flex min-h-dvh flex-col items-center justify-center px-6 text-center"
+      id="main"
+      tabIndex={-1}
+    >
       <p className="font-mono text-xs tracking-widest text-[var(--color-danger)] uppercase">
         Access Denied
       </p>

--- a/apps/web/app/_components/landing/footer.tsx
+++ b/apps/web/app/_components/landing/footer.tsx
@@ -35,7 +35,10 @@ export function LandingFooter() {
         <div className="mx-auto flex max-w-7xl flex-col gap-2 px-6 py-5 font-mono text-[10px] tracking-[0.28em] text-slate-500 uppercase sm:flex-row sm:items-center sm:justify-between sm:px-10">
           <span>© 2026 FreightMatch · All systems nominal</span>
           <span className="flex items-center gap-2">
-            <span className="inline-block h-1.5 w-1.5 animate-[status-flicker_3s_ease-in-out_infinite] rounded-full bg-[var(--color-go)]" />
+            <span
+              aria-hidden="true"
+              className="inline-block h-1.5 w-1.5 rounded-full bg-[var(--color-go)] shadow-[0_0_8px_rgba(61,214,140,0.55)]"
+            />
             uptime · 99.98%
           </span>
         </div>

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+
+const ASCII = `
+   ███████╗ ██████╗  ██████╗
+   ██╔════╝██╔═████╗██╔═████╗
+   ███████╗██║██╔██║██║██╔██║
+   ╚════██║████╔╝██║████╔╝██║
+   ███████║╚██████╔╝╚██████╔╝
+   ╚══════╝ ╚═════╝  ╚═════╝
+`;
+
+export default function ErrorBoundary({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  React.useEffect(() => {
+    if (process.env.NODE_ENV !== "production") {
+      console.error("[error.tsx]", error);
+    }
+  }, [error]);
+
+  return (
+    <main
+      className="flex min-h-dvh flex-col items-center justify-center px-6 text-center"
+      id="main"
+      tabIndex={-1}
+    >
+      <p className="font-mono text-[11px] tracking-[0.32em] text-[var(--color-danger)] uppercase">
+        System fault
+      </p>
+      <pre
+        aria-hidden="true"
+        className="mt-4 font-mono text-[10px] leading-tight whitespace-pre text-[var(--color-danger)]/85 sm:text-xs"
+      >
+        {ASCII}
+      </pre>
+      <h1 className="sr-only">Internal server error</h1>
+      <p className="mt-3 max-w-md font-mono text-xs tracking-[0.18em] text-slate-400 uppercase">
+        The console hit an unexpected condition. Telemetry has logged the trace.
+      </p>
+      {error.digest ? (
+        <p className="mt-2 font-mono text-[10px] tracking-[0.28em] text-slate-600 uppercase">
+          trace · {error.digest}
+        </p>
+      ) : null}
+      <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+        <button
+          className="fm-focus-ring inline-flex items-center gap-2 rounded-md border border-amber-400 bg-amber-400 px-4 py-2.5 font-mono text-[11px] font-semibold tracking-[0.24em] text-slate-950 uppercase shadow-[0_0_24px_rgba(245,179,66,0.18)] transition-colors hover:border-amber-500 hover:bg-amber-500"
+          onClick={reset}
+          type="button"
+        >
+          Retry
+        </button>
+        <Link
+          className="fm-focus-ring inline-flex items-center gap-2 rounded-md border border-slate-700 bg-slate-900 px-4 py-2.5 font-mono text-[11px] font-semibold tracking-[0.24em] text-slate-200 uppercase transition-colors hover:border-slate-500 hover:bg-slate-800"
+          href="/"
+        >
+          Return to base
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="en">
+      <body
+        style={{
+          backgroundColor: "#0a0e12",
+          color: "#e2e8f0",
+          fontFamily: 'var(--font-jetbrains-mono), "JetBrains Mono", ui-monospace, monospace',
+          margin: 0,
+          minHeight: "100dvh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: "1.5rem",
+          textAlign: "center",
+        }}
+      >
+        <main style={{ maxWidth: "32rem" }}>
+          <p
+            style={{
+              color: "#e5484d",
+              fontSize: "11px",
+              letterSpacing: "0.32em",
+              textTransform: "uppercase",
+              margin: 0,
+            }}
+          >
+            Critical fault
+          </p>
+          <h1
+            style={{
+              color: "#f1f5f9",
+              fontSize: "2.25rem",
+              fontWeight: 700,
+              letterSpacing: "0.04em",
+              margin: "0.75rem 0 0.5rem",
+            }}
+          >
+            FreightMatch is offline
+          </h1>
+          {error.digest ? (
+            <p
+              style={{
+                color: "#475569",
+                fontSize: "10px",
+                letterSpacing: "0.28em",
+                textTransform: "uppercase",
+                margin: 0,
+              }}
+            >
+              trace · {error.digest}
+            </p>
+          ) : null}
+          <button
+            onClick={reset}
+            style={{
+              backgroundColor: "#f5b342",
+              border: "1px solid #f5b342",
+              borderRadius: "6px",
+              color: "#0a0e12",
+              cursor: "pointer",
+              fontFamily: "inherit",
+              fontSize: "11px",
+              fontWeight: 600,
+              letterSpacing: "0.24em",
+              marginTop: "1.75rem",
+              padding: "0.625rem 1rem",
+              textTransform: "uppercase",
+            }}
+            type="button"
+          >
+            Retry
+          </button>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -53,8 +53,23 @@ body {
 .fm-focus-ring:focus-visible {
   border-color: rgba(245, 179, 66, 0.85);
   box-shadow:
-    0 0 0 1px rgba(245, 179, 66, 0.95),
-    0 0 0 4px rgba(245, 179, 66, 0.16);
+    0 0 0 2px rgba(10, 14, 18, 0.95),
+    0 0 0 5px rgba(245, 179, 66, 0.55);
+}
+
+.fm-skip-link {
+  clip-path: inset(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 .fm-panel-surface {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist } from "next/font/google";
 import { JetBrains_Mono } from "next/font/google";
 import { GridBackdrop } from "@/components/GridBackdrop";
+import { SkipToMain } from "@/components/SkipToMain";
 import { Providers } from "./providers";
 import "leaflet/dist/leaflet.css";
 import "react-image-crop/dist/ReactCrop.css";
@@ -31,6 +32,7 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${geist.variable} ${jetbrainsMono.variable}`}>
       <body className="antialiased">
+        <SkipToMain />
         <GridBackdrop />
         <Providers>{children}</Providers>
       </body>

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+
+const ASCII = `
+   ██╗  ██╗ ██████╗ ██╗  ██╗
+   ██║  ██║██╔═████╗██║  ██║
+   ███████║██║██╔██║███████║
+   ╚════██║████╔╝██║╚════██║
+        ██║╚██████╔╝     ██║
+        ╚═╝ ╚═════╝      ╚═╝
+`;
+
+export default function NotFound() {
+  return (
+    <main
+      className="flex min-h-dvh flex-col items-center justify-center px-6 text-center"
+      id="main"
+      tabIndex={-1}
+    >
+      <p className="font-mono text-[11px] tracking-[0.32em] text-amber-400 uppercase">
+        Signal lost
+      </p>
+      <pre
+        aria-hidden="true"
+        className="mt-4 font-mono text-[10px] leading-tight whitespace-pre text-amber-400/80 sm:text-xs"
+      >
+        {ASCII}
+      </pre>
+      <h1 className="sr-only">Page not found</h1>
+      <p className="mt-3 max-w-sm font-mono text-xs tracking-[0.18em] text-slate-400 uppercase">
+        No matching route on the freight grid.
+      </p>
+      <Link
+        className="fm-focus-ring mt-8 inline-flex items-center gap-2 rounded-md border border-amber-400 bg-amber-400 px-4 py-2.5 font-mono text-[11px] font-semibold tracking-[0.24em] text-slate-950 uppercase shadow-[0_0_24px_rgba(245,179,66,0.18)] transition-colors hover:border-amber-500 hover:bg-amber-500"
+        href="/"
+      >
+        Return to base
+      </Link>
+    </main>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -6,7 +6,7 @@ import { OpsStrip } from "./_components/landing/ops-strip";
 
 export default function HomePage() {
   return (
-    <main className="flex min-h-dvh flex-col">
+    <main className="flex min-h-dvh flex-col" id="main" tabIndex={-1}>
       <Hero />
       <FeatureGrid />
       <OpsStrip />

--- a/apps/web/components/SkipToMain.tsx
+++ b/apps/web/components/SkipToMain.tsx
@@ -1,0 +1,10 @@
+export function SkipToMain() {
+  return (
+    <a
+      className="fm-skip-link fm-focus-ring fixed left-3 top-3 z-[1000] -translate-y-24 rounded-md border border-amber-400/70 bg-slate-950 px-3 py-2 font-mono text-[11px] uppercase tracking-[0.24em] text-amber-300 shadow-lg transition-transform duration-150 focus:translate-y-0"
+      href="#main"
+    >
+      Skip to main content
+    </a>
+  );
+}

--- a/apps/web/components/chat/chat-panel.tsx
+++ b/apps/web/components/chat/chat-panel.tsx
@@ -36,14 +36,18 @@ function MessageList({ variant }: { variant: "drawer" | "page" }) {
 
   return (
     <div
+      aria-live="polite"
+      aria-relevant="additions text"
       className={cn(
         "min-h-0 flex-1 overflow-y-auto px-4 py-5",
         variant === "page" ? "sm:px-6 lg:px-8" : "sm:px-6",
       )}
+      role="log"
     >
       {!isHydrated ? (
         <div className="flex h-full items-center justify-center font-mono text-sm text-amber-400">
-          ◐
+          <span aria-hidden="true">◐</span>
+          <span className="sr-only">Loading conversation</span>
         </div>
       ) : messages.length === 0 ? (
         <div className="flex h-full items-center justify-center">
@@ -108,7 +112,10 @@ function MessageBubble({ message }: { message: AssistantChatMessage }) {
             </div>
           )
         ) : (
-          <p className="font-mono text-lg text-amber-400">◐</p>
+          <p className="font-mono text-lg text-amber-400" role="status">
+            <span aria-hidden="true">◐</span>
+            <span className="sr-only">Generating response</span>
+          </p>
         )}
       </div>
     </article>


### PR DESCRIPTION
Closes #62.

## Summary
- Skip-to-main link wired to `id="main"` on every layout (`(carrier)`, `(shipper)`, `(shared)`, `(auth)`, landing, `403`)
- Themed `not-found.tsx`, `error.tsx`, `global-error.tsx` with ASCII codes and "Return to base" buttons
- Global `prefers-reduced-motion` override neutralizes all animations/transitions
- Footer infinite status flicker replaced with a steady glow indicator (no more infinite loops on functional pages)
- `fm-focus-ring` strengthened: inner dark ring + outer amber glow so primary amber buttons remain visibly focusable
- Chat panel: `role="log"` + `aria-live="polite"` for the message list; `sr-only` labels for spinner glyphs
- New `apps/web/TESTING.md` — manual QA checklist for the X3 golden paths

## Acceptance criteria checklist
- [x] Skip-to-main on every page
- [x] Focus rings visible on amber backgrounds
- [x] Form labels bound, errors announced (existing Input primitive + role=alert on form-level errors)
- [x] Themed 404 + 500 with ASCII art + return-to-base
- [x] All loading/empty/error states audited
- [x] prefers-reduced-motion respected globally
- [x] No infinite animations on functional pages (hero corridor pulses on / neutralized under reduced-motion)
- [x] Heavy deps already code-split (Leaflet via next/dynamic + ssr:false; Motion via LazyMotion + domAnimation)
- [x] pnpm typecheck / lint / build all green

## Out of scope
- Lighthouse score targets and Axe DevTools sweep — both gated as manual QA in TESTING.md, run against preview deploy before promoting to release branch