### PR TITLE
docs: rewrite ARCHITECTURE.md with renderable Mermaid diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Microservices-based freight matching platform connecting shippers with carriers 
 ![CI](https://github.com/yigitbozyaka/freightmatch/actions/workflows/ci.yml/badge.svg)
 
 📑 **Detailed Project Report:** [PROJECT_REPORT.md](PROJECT_REPORT.md) — full system walkthrough covering architecture, microservices, Kafka, security, AI, CI/CD, and engineering decisions.
+📐 **Architecture Diagrams:** [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — system topology, load lifecycle, auth flow, and domain state machines (Mermaid).
 
 📘 **API Reference:** [FreightMatch API Documentation](https://yigitbozyaka.github.io/freightmatch/)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,7 @@ All external traffic enters through NGINX on port 80; the four microservices, th
 
 ```mermaid
 flowchart TB
-    Browser["Browser\n(HTTPS + HttpOnly cookies)"]
+    Browser["Browser<br/>(HTTPS + HttpOnly cookies)"]
 
     Browser -->|"HTTPS, HttpOnly cookies"| NGINX
 
@@ -70,9 +70,14 @@ sequenceDiagram
 
     Shipper->>NGINX: POST /api/loads
     NGINX->>LS: forward
-    LS->>LS: create Load (status: Posted)
-    LS->>Kafka: publish load.created
+    LS->>LS: create Load (status: Draft)
     LS-->>Shipper: 201 Load created
+
+    Shipper->>NGINX: PATCH /api/loads/:id (status: Posted)
+    NGINX->>LS: forward
+    LS->>LS: transition Draft -> Posted
+    LS->>Kafka: publish load.created
+    LS-->>Shipper: 200 Load published
 
     Kafka->>MS: consume load.created
     MS->>US: GET /api/internal/carriers (x-internal-secret)
@@ -118,7 +123,7 @@ The Next.js BFF proxy intercepts every `/api/*` call, manages HttpOnly cookies, 
 ```mermaid
 sequenceDiagram
     participant Browser as Browser
-    participant BFF as "Next.js BFF proxy\n(/api/proxy/[...path])"
+    participant BFF as Next.js BFF proxy
     participant NGINX as NGINX
     participant US as user-service
 
@@ -130,7 +135,9 @@ sequenceDiagram
     Note over US: check lockout (5 fails = 423, 15 min lock)
     US-->>BFF: 200 {accessToken, refreshToken, user}
     BFF->>BFF: strip tokens from JSON body
-    BFF-->>Browser: 200 {user}\n+ Set-Cookie: fm_access (HttpOnly, sameSite=lax, 15min, secure in prod)\n+ Set-Cookie: fm_refresh (HttpOnly, sameSite=strict, 30d, always secure)
+    BFF-->>Browser: 200 {user}
+    Note over BFF,Browser: Set-Cookie: fm_access (HttpOnly, sameSite=lax, 15min, secure in prod)
+    Note over BFF,Browser: Set-Cookie: fm_refresh (HttpOnly, sameSite=strict, 30d, always secure)
 
     Note over Browser,US: Authenticated request
     Browser->>BFF: GET /api/loads (cookie: fm_access)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,256 +1,255 @@
-# FreightMatch System Architecture
+# FreightMatch — Architecture
 
-## Updated Architecture Diagram
+A visual map of how the FreightMatch services fit together. Each diagram below answers one specific question. For the narrative version, see [PROJECT_REPORT.md](../PROJECT_REPORT.md).
+
+## 1. System topology
+
+All external traffic enters through NGINX on port 80; the four microservices, their MongoDB databases, the Kafka event bus, and OpenRouter are only reachable internally.
 
 ```mermaid
-graph TB
-    subgraph "Client Layer"
-        CLIENT[Client Applications<br/>Web / Mobile / API]
+flowchart TB
+    Browser["Browser\n(HTTPS + HttpOnly cookies)"]
+
+    Browser -->|"HTTPS, HttpOnly cookies"| NGINX
+
+    NGINX["NGINX gateway :80"]
+
+    subgraph Services
+        US["user-service :3001"]
+        LS["load-service :3002"]
+        BS["bidding-service :3003"]
+        MS["matching-service :3004"]
     end
 
-    subgraph "Security Gateway"
-        NGINX[NGINX Reverse Proxy<br/>Port 80]
-        NGINX_SEC[Security Headers<br/>HSTS, CSP, X-Frame-Options<br/>X-Content-Type-Options]
-        NGINX_RL[Rate Limiting<br/>api_auth: 5r/s<br/>api_general: 30r/s<br/>api_chat: 2r/s]
-        NGINX --- NGINX_SEC
-        NGINX --- NGINX_RL
-    end
-
-    subgraph "Authentication Layer"
-        JWT[JWT Authentication<br/>Access: 15min / Refresh: 7d]
-        RBAC[Role-Based Access Control<br/>Shipper | Carrier]
-        LOCKOUT[Account Lockout<br/>5 failures → 15min lock]
-        BLACKLIST[Token Blacklist<br/>Logout Revocation]
-        JWT --- RBAC
-        JWT --- LOCKOUT
-        JWT --- BLACKLIST
-    end
-
-    subgraph "Microservices"
-        subgraph "User Service :3001"
-            US[Express + Helmet + CORS]
-            US_AUTH[Auth: Register / Login<br/>Logout / Refresh]
-            US_PWD[Password Security<br/>bcrypt 12 rounds<br/>Complexity Rules]
-            US_CARRIER[Carrier Profiles<br/>Internal Auth]
-            US --- US_AUTH
-            US --- US_PWD
-            US --- US_CARRIER
-        end
-
-        subgraph "Load Service :3002"
-            LS[Express + Helmet + CORS]
-            LS_CRUD[Load CRUD<br/>Status Transitions]
-            LS_RL[Rate Limiter<br/>100 req/15min]
-            LS --- LS_CRUD
-            LS --- LS_RL
-        end
-
-        subgraph "Bidding Service :3003"
-            BS[Express + Helmet + CORS]
-            BS_BIDS[Bid Management<br/>Submit / Accept]
-            BS_RL[Rate Limiter<br/>100 req/15min<br/>Bids: 20/15min]
-            BS --- BS_BIDS
-            BS --- BS_RL
-        end
-
-        subgraph "Matching Service :3004"
-            MS[Express + Helmet + CORS]
-            MS_MATCH[AI Carrier Matching<br/>Auto-recommendations]
-            MS_CHAT[AI Freight Chatbot<br/>Route / Pricing / Advice]
-            MS_RL[Rate Limiter<br/>60 req/15min<br/>Chat: 20/15min]
-            MS --- MS_MATCH
-            MS --- MS_CHAT
-            MS --- MS_RL
-        end
-    end
-
-    subgraph "AI Layer"
-        OPENROUTER[OpenRouter API<br/>LLM Provider]
-        CLAUDE[Claude 3.5 Haiku<br/>Matching: temp 0.3<br/>Chat: temp 0.7]
-        FALLBACK[Fallback Algorithm<br/>Rating-based ranking]
-        OPENROUTER --- CLAUDE
-        MS_MATCH --> OPENROUTER
-        MS_CHAT --> OPENROUTER
-        MS_MATCH -.->|API failure| FALLBACK
-    end
-
-    subgraph "Event Bus"
-        KAFKA[Apache Kafka]
-        TOPIC1[load.created]
-        TOPIC2[bid.accepted]
-        KAFKA --- TOPIC1
-        KAFKA --- TOPIC2
-    end
-
-    subgraph "Data Layer"
-        MONGO[(MongoDB 7<br/>Replica Set)]
-        DB1[(freightmatch-users)]
-        DB2[(freightmatch-loads)]
-        DB3[(freightmatch-bidding)]
-        DB4[(freightmatch-matching)]
-        MONGO --- DB1
-        MONGO --- DB2
-        MONGO --- DB3
-        MONGO --- DB4
-    end
-
-    subgraph "Observability"
-        PROM[Prometheus<br/>Metrics Collection]
-        GRAFANA[Grafana<br/>Dashboards]
-        OTEL[OpenTelemetry<br/>Distributed Tracing]
-        WINSTON[Winston + Loki<br/>Structured Logging]
-        PROM --> GRAFANA
-    end
-
-    subgraph "Secrets Management"
-        ENV[Environment Variables<br/>Zod Validated]
-        SEC_JWT[JWT Secrets<br/>min 32 chars]
-        SEC_INT[Internal Secret<br/>min 16 chars]
-        SEC_API[API Keys<br/>OpenRouter]
-        ENV --- SEC_JWT
-        ENV --- SEC_INT
-        ENV --- SEC_API
-    end
-
-    CLIENT --> NGINX
     NGINX --> US
     NGINX --> LS
     NGINX --> BS
     NGINX --> MS
+
+    subgraph Databases
+        DB1[("freightmatch-users")]
+        DB2[("freightmatch-loads")]
+        DB3[("freightmatch-bidding")]
+        DB4[("freightmatch-matching")]
+    end
 
     US --> DB1
     LS --> DB2
     BS --> DB3
     MS --> DB4
 
-    LS -->|publish| TOPIC1
-    BS -->|publish| TOPIC2
-    MS -->|subscribe| TOPIC1
+    subgraph KafkaTopics["Kafka topics"]
+        T1["load.created"]
+        T2["bid.accepted"]
+    end
 
-    MS -->|x-internal-secret| US_CARRIER
+    LS -->|"publish"| T1
+    T1 -->|"subscribe"| MS
+    BS -->|"publish"| T2
+    T2 -->|"subscribe"| LS
 
-    US --> PROM
-    LS --> PROM
-    BS --> PROM
-    MS --> PROM
-
-    US --> OTEL
-    LS --> OTEL
-    BS --> OTEL
-    MS --> OTEL
+    MS -->|"x-internal-secret"| US
+    MS -->|"Claude 3.5 Haiku"| OR["OpenRouter"]
 ```
 
-## Security Flow Diagram
+## 2. Load lifecycle — end-to-end sequence
+
+Traces a load from creation through carrier matching, bid acceptance, and final delivery.
 
 ```mermaid
 sequenceDiagram
-    participant C as Client
-    participant N as NGINX Gateway
-    participant U as User Service
-    participant DB as MongoDB
-    participant L as Load Service
-    participant K as Kafka
-    participant M as Matching Service
-    participant AI as OpenRouter (Claude)
+    participant Shipper as Shipper (browser)
+    participant NGINX as NGINX
+    participant LS as load-service
+    participant Kafka as Kafka
+    participant MS as matching-service
+    participant US as user-service
+    participant OR as OpenRouter
+    participant BS as bidding-service
+    participant Carrier as Carrier (browser)
 
-    Note over N: Rate Limiting Check
-    Note over N: Security Headers Applied
+    Shipper->>NGINX: POST /api/loads
+    NGINX->>LS: forward
+    LS->>LS: create Load (status: Posted)
+    LS->>Kafka: publish load.created
+    LS-->>Shipper: 201 Load created
 
-    C->>N: POST /api/users/register
-    N->>U: Forward (rate: 5r/s)
-    Note over U: Zod Validation
-    Note over U: Password Complexity Check
-    U->>DB: Hash password (bcrypt 12)
-    U-->>C: 201 Created
+    Kafka->>MS: consume load.created
+    MS->>US: GET /api/internal/carriers (x-internal-secret)
+    US-->>MS: carrier list
+    MS->>OR: rank carriers (temp 0.3)
+    OR-->>MS: ranked recommendations
+    Note over MS: fallback ranking if LLM call fails
+    MS->>MS: store recommendations
 
-    C->>N: POST /api/users/login
-    N->>U: Forward (rate: 5r/s)
-    Note over U: Check Account Lockout
-    U->>DB: Verify credentials
-    alt Invalid Password
-        Note over U: Increment failed attempts
-        alt 5+ failures
-            Note over U: Lock account 15min
-        end
-        U-->>C: 401/423 Error
-    else Valid Password
-        Note over U: Reset failed attempts
-        Note over U: Sign JWT (15min + 7d refresh)
-        U-->>C: 200 {accessToken, refreshToken}
-    end
+    Carrier->>NGINX: GET /api/loads (marketplace)
+    NGINX->>LS: forward
+    LS-->>Carrier: load list
 
-    C->>N: POST /api/loads (Bearer token)
-    N->>L: Forward (rate: 30r/s)
-    Note over L: JWT Verification
-    Note over L: Role: Shipper only
-    L->>DB: Create Load
-    L->>K: Publish load.created
-    L-->>C: 201 Load Created
+    Carrier->>NGINX: POST /api/bids
+    NGINX->>BS: forward
+    BS->>BS: store bid (status: Pending)
+    BS-->>Carrier: 201 Bid submitted
 
-    K->>M: Consume load.created
-    M->>U: GET /api/users/carriers<br/>(x-internal-secret)
-    Note over U: Validate Internal Secret
-    U-->>M: Carrier List
-    M->>AI: Rank carriers (temp: 0.3)
-    AI-->>M: Top 3 recommendations
-    M->>DB: Store recommendations
+    Shipper->>NGINX: PUT /api/bids/:id/accept
+    NGINX->>BS: forward
+    BS->>BS: mark bid Accepted
+    BS->>BS: mark sibling bids Rejected
+    Note over BS: one Accepted bid per load
+    BS->>Kafka: publish bid.accepted
+    BS-->>Shipper: 200 Bid accepted
 
-    C->>N: POST /api/chat (Bearer token)
-    N->>M: Forward (rate: 2r/s)
-    Note over M: JWT Verification
-    Note over M: App Rate Limit (20/15min)
-    M->>AI: Chat query (temp: 0.7)
-    AI-->>M: AI Response
-    M-->>C: {reply, model, tokensUsed}
+    Kafka->>LS: consume bid.accepted
+    LS->>LS: transition Load to Matched
 
-    C->>N: POST /api/users/logout (Bearer token)
-    N->>U: Forward
-    Note over U: Blacklist access + refresh tokens
-    U-->>C: 200 Logged Out
+    Shipper->>NGINX: PATCH /api/loads/:id (status: InTransit)
+    NGINX->>LS: forward
+    LS->>LS: transition Matched -> InTransit
+
+    Shipper->>NGINX: PATCH /api/loads/:id (status: Delivered)
+    NGINX->>LS: forward
+    LS->>LS: transition InTransit -> Delivered
 ```
 
-## Service Communication Matrix
+## 3. Authentication & cookie flow
+
+The Next.js BFF proxy intercepts every `/api/*` call, manages HttpOnly cookies, and handles silent token refresh so the browser never touches raw JWTs.
 
 ```mermaid
-graph LR
-    subgraph "External"
-        C[Client]
-        OR[OpenRouter API]
-    end
+sequenceDiagram
+    participant Browser as Browser
+    participant BFF as "Next.js BFF proxy\n(/api/proxy/[...path])"
+    participant NGINX as NGINX
+    participant US as user-service
 
-    subgraph "Internal Network"
-        N[NGINX :80]
-        US[User :3001]
-        LS[Load :3002]
-        BS[Bidding :3003]
-        MS[Matching :3004]
-        K[Kafka :9092]
-        M[(MongoDB :27017)]
-    end
+    Note over Browser,US: Login
+    Browser->>BFF: POST /api/users/login {email, password}
+    BFF->>NGINX: forward to user-service
+    NGINX->>US: POST /api/users/login
+    Note over US: check isApproved — reject if false
+    Note over US: check lockout (5 fails = 423, 15 min lock)
+    US-->>BFF: 200 {accessToken, refreshToken, user}
+    BFF->>BFF: strip tokens from JSON body
+    BFF-->>Browser: 200 {user}\n+ Set-Cookie: fm_access (HttpOnly, sameSite=lax, 15min, secure in prod)\n+ Set-Cookie: fm_refresh (HttpOnly, sameSite=strict, 30d, always secure)
 
-    C -->|HTTPS| N
-    N -->|HTTP| US
-    N -->|HTTP| LS
-    N -->|HTTP| BS
-    N -->|HTTP| MS
+    Note over Browser,US: Authenticated request
+    Browser->>BFF: GET /api/loads (cookie: fm_access)
+    BFF->>BFF: attach Authorization: Bearer fm_access
+    BFF->>NGINX: GET /api/loads
+    NGINX->>US: forward (JWT verified by service)
+    US-->>BFF: 200 data
+    BFF-->>Browser: 200 data
 
-    MS -->|x-internal-secret| US
-    BS -->|x-internal-secret| LS
+    Note over Browser,US: Silent refresh on 401
+    Browser->>BFF: GET /api/loads (expired fm_access)
+    BFF->>NGINX: forward with expired token
+    NGINX-->>BFF: 401
+    BFF->>NGINX: POST /api/users/refresh (cookie: fm_refresh)
+    NGINX->>US: POST /api/users/refresh
+    US-->>BFF: 200 {accessToken}
+    BFF->>BFF: set new fm_access cookie
+    BFF->>NGINX: retry original GET /api/loads
+    NGINX-->>BFF: 200 data
+    BFF-->>Browser: 200 data (new fm_access cookie set)
 
-    LS -->|produce| K
-    BS -->|produce| K
-    MS -->|consume| K
+    Note over BFF: second 401 = clear both cookies, return 401
 
-    MS -->|HTTPS| OR
+    Note over Browser,US: Logout
+    Browser->>BFF: POST /api/users/logout
+    BFF->>NGINX: forward with both tokens
+    NGINX->>US: POST /api/users/logout
+    US->>US: blacklist fm_access + fm_refresh
+    US-->>BFF: 200
+    BFF->>BFF: clear fm_access + fm_refresh cookies
+    BFF-->>Browser: 200
+```
 
-    US --> M
-    LS --> M
-    BS --> M
-    MS --> M
+## 4. Domain model & state machines
 
-    style C fill:#e1f5fe
-    style OR fill:#fff3e0
-    style N fill:#c8e6c9
-    style K fill:#f3e5f5
-    style M fill:#ffecb3
+### Entity relationships
+
+```mermaid
+erDiagram
+    USER {
+        string id
+        string email
+        string role "Shipper or Carrier"
+        boolean isApproved
+        int failedLoginAttempts
+        date lockUntil
+    }
+    CARRIER_PROFILE {
+        string truckType "flatbed / refrigerated / dry-van / tanker"
+        number capacityKg
+        string homeCity
+        number rating
+        int completedShipments
+        number avgEtaHours
+        number trustScore
+    }
+    SHIPPER_PROFILE {
+        string companyName
+        int completedLoads
+        number avgTimeToAcceptHours
+    }
+    LOAD {
+        string id
+        string shipperId
+        string title
+        string origin
+        string destination
+        string cargoType
+        number weightKg
+        number deadlineHours
+        string status
+    }
+    BID {
+        string id
+        string loadId
+        string carrierId
+        number priceUSD
+        number estimatedDeliveryHours
+        string status
+    }
+    RECOMMENDATION {
+        string id
+        string loadId
+        string carrierId
+        number score
+        string reasoning
+    }
+
+    USER ||--o| CARRIER_PROFILE : "has"
+    USER ||--o| SHIPPER_PROFILE : "has"
+    USER ||--o{ LOAD : "posts"
+    USER ||--o{ BID : "submits"
+    LOAD ||--o{ BID : "receives"
+    LOAD ||--o{ RECOMMENDATION : "ranked for"
+```
+
+### Load state machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft
+    Draft --> Posted : shipper publishes
+    Draft --> Cancelled : shipper cancels
+    Posted --> Matched : bid.accepted event
+    Posted --> Cancelled : shipper cancels
+    Matched --> InTransit : shipper confirms pickup
+    Matched --> Cancelled : shipper cancels
+    InTransit --> Delivered : shipper confirms delivery
+    Delivered --> [*]
+    Cancelled --> [*]
+```
+
+### Bid state machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending
+    Pending --> Accepted : shipper accepts
+    Pending --> Rejected : shipper rejects OR sibling accepted
+    Accepted --> [*]
+    Rejected --> [*]
 ```


### PR DESCRIPTION
## Summary

- Replaces the old `docs/ARCHITECTURE.md` (which failed to render on GitHub — Mermaid parse errors from bare pipes in node labels like `[Shipper | Carrier]`) with four focused, GitHub-renderable diagrams.
- Adds an "Architecture Diagrams" link in `README.md` directly under the existing `PROJECT_REPORT.md` reference.
- Diagrams included: **system topology**, **load lifecycle sequence**, **auth & cookie flow**, **domain ER + state machines** (Load and Bid).
- Content verified against current source — load state machine uses `Draft|Posted|Matched|InTransit|Delivered|Cancelled` (not "Booked"), refresh cookie is 30 days, `isApproved` gate is shown.

Closes #98

## Test plan

- [ ] Open the PR's Files Changed tab on GitHub; each of the **six** Mermaid code blocks renders as a diagram (no "Unable to render rich display" error).
- [ ] **Diagram 1 (System topology)** — Shows Browser → NGINX, four services, four MongoDB databases, two Kafka topics with publish/subscribe edges, matching-service → user-service (x-internal-secret), matching-service → OpenRouter.
- [ ] **Diagram 2 (Load lifecycle)** — Walks from POST `/api/loads` (creates Draft, no Kafka event) → PATCH to Posted (fires `load.created`) → matching → carrier bidding → accept (fires `bid.accepted`) → load transitions to Matched → InTransit → Delivered.
- [ ] **Diagram 3 (Auth flow)** — Login sets HttpOnly cookies `fm_access` (15min, sameSite=lax) and `fm_refresh` (30d, sameSite=strict). Includes silent refresh on 401, `isApproved` reject path, account lockout note, and logout cookie clear.
- [ ] **Diagram 4a (ER diagram)** — Shows `USER` polymorphic to `CARRIER_PROFILE` / `SHIPPER_PROFILE`, plus `LOAD`, `BID`, `RECOMMENDATION` with correct cardinalities.
- [ ] **Diagram 4b (Load state machine)** — Exactly matches `VALID_TRANSITIONS` in `services/load-service/src/models/load.model.ts`: Draft → Posted/Cancelled, Posted → Matched/Cancelled, Matched → InTransit/Cancelled, InTransit → Delivered.
- [ ] **Diagram 4c (Bid state machine)** — Pending → Accepted | Rejected, both terminal.
- [ ] No `\n` literals anywhere in the file (use `<br/>` or split steps); no bare `|` inside any `[ ]` node label.
- [ ] README has the new `📐 **Architecture Diagrams:**` line directly below the `📑 **Detailed Project Report:**` line; the link `[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)` is clickable and resolves.
- [ ] No files outside `docs/ARCHITECTURE.md` and `README.md` are changed (verify via the Files Changed tab — should show exactly 2 files).