### PR TITLE
fix(bidding-service): send correct internal auth header when fetching load

### DIFF
--- a/services/bidding-service/src/services/bid.service.ts
+++ b/services/bidding-service/src/services/bid.service.ts
@@ -87,7 +87,7 @@ export class BidService {
   private async fetchLoad(loadId: string): Promise<{ shipperId: string }> {
     try {
       const response = await axios.get(`${env.LOAD_SERVICE_URL}/api/loads/${loadId}`, {
-        headers: { 'x-internal-request': 'true' },
+        headers: { 'x-internal-secret': env.INTERNAL_SERVICE_SECRET },
       });
       return response.data;
     } catch (err) {


### PR DESCRIPTION
## Summary

- `BidService.fetchLoad()` was sending `x-internal-request: 'true'` to the load-service
- The load-service `authenticateOrInternal` middleware checks for `x-internal-secret` matched against `INTERNAL_SERVICE_SECRET`
- Mismatch caused the request to fall through to JWT validation with no token → auth failure → 502 on `POST /bids/:id/accept`

**Fix:** replace the wrong header with `x-internal-secret: env.INTERNAL_SERVICE_SECRET` (the env var was already present in the bidding-service config).

## Test plan

- [ ] Accept a bid as a shipper — response should be 200, not 502
- [ ] Confirm the accepted bid's load is correctly fetched (shipperId authorization check passes)
- [ ] Verify a shipper cannot accept a bid on a load they don't own (403 still returned)
- [ ] Verify 404 is returned when the load does not exist