### PR TITLE
feat: carrier confirm-pickup and confirm-delivery

### DIFF
--- a/apps/web/app/(carrier)/marketplace/[id]/page.tsx
+++ b/apps/web/app/(carrier)/marketplace/[id]/page.tsx
@@ -128,6 +128,30 @@ export default function CarrierLoadDetailPage() {
     setDrawerOpen(true);
   }, [isProfileComplete, loadQuery.data?.deadlineHours, myBidForLoad]);
 
+  const pickupMutation = useMutation({
+    mutationFn: () => loadsApi.confirmPickup(loadId!),
+    onSuccess: (data) => {
+      queryClient.setQueryData(["loads", loadId], data);
+      void queryClient.invalidateQueries({ queryKey: ["loads"] });
+      pushToast("Pickup confirmed");
+    },
+    onError: () => {
+      pushToast("Could not confirm pickup. Try again.", "error");
+    },
+  });
+
+  const deliveryMutation = useMutation({
+    mutationFn: () => loadsApi.confirmDelivery(loadId!),
+    onSuccess: (data) => {
+      queryClient.setQueryData(["loads", loadId], data);
+      void queryClient.invalidateQueries({ queryKey: ["loads"] });
+      pushToast("Delivery confirmed");
+    },
+    onError: () => {
+      pushToast("Could not confirm delivery. Try again.", "error");
+    },
+  });
+
   const submitMutation = useMutation({
     mutationFn: (input: CreateBidInput) => bidsApi.create(input),
     onSuccess: (bid) => {
@@ -248,6 +272,10 @@ export default function CarrierLoadDetailPage() {
             isProfileComplete={isProfileComplete}
             onPlaceBid={handleOpenDrawer}
             loadStatus={load.status}
+            onConfirmPickup={() => pickupMutation.mutate()}
+            onConfirmDelivery={() => deliveryMutation.mutate()}
+            isPickupPending={pickupMutation.isPending}
+            isDeliveryPending={deliveryMutation.isPending}
           />
 
           {!isProfileComplete ? <ProfileGateCallout /> : null}
@@ -372,15 +400,25 @@ function YourBidPanel({
   isProfileComplete,
   onPlaceBid,
   loadStatus,
+  onConfirmPickup,
+  onConfirmDelivery,
+  isPickupPending,
+  isDeliveryPending,
 }: {
   bid: Bid | null;
   isProfileComplete: boolean;
   onPlaceBid: () => void;
   loadStatus: Load["status"];
+  onConfirmPickup?: () => void;
+  onConfirmDelivery?: () => void;
+  isPickupPending?: boolean;
+  isDeliveryPending?: boolean;
 }) {
   const acceptingBids = loadStatus === "Posted";
 
   if (bid) {
+    const anyPending = Boolean(isPickupPending || isDeliveryPending);
+
     return (
       <section className="fm-panel-surface rounded-lg p-5">
         <div className="flex items-center justify-between gap-3">
@@ -407,6 +445,34 @@ function YourBidPanel({
             changes.
           </p>
         </div>
+        {bid.status === "Accepted" && loadStatus === "Matched" && onConfirmPickup ? (
+          <div className="mt-5">
+            <Button
+              variant="primary"
+              className="w-full"
+              onClick={onConfirmPickup}
+              loading={isPickupPending}
+              disabled={anyPending}
+            >
+              <Truck className="h-3.5 w-3.5" aria-hidden="true" />
+              Confirm pickup
+            </Button>
+          </div>
+        ) : null}
+        {bid.status === "Accepted" && loadStatus === "InTransit" && onConfirmDelivery ? (
+          <div className="mt-5">
+            <Button
+              variant="primary"
+              className="w-full"
+              onClick={onConfirmDelivery}
+              loading={isDeliveryPending}
+              disabled={anyPending}
+            >
+              <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
+              Confirm delivery
+            </Button>
+          </div>
+        ) : null}
       </section>
     );
   }

--- a/apps/web/lib/api/loads.ts
+++ b/apps/web/lib/api/loads.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+﻿import { z } from "zod";
 import { apiFetch } from "./client";
 
 const LoadStatusSchema = z.enum([
@@ -13,6 +13,7 @@ const LoadStatusSchema = z.enum([
 const LoadSchema = z.object({
   _id: z.string(),
   shipperId: z.string().optional(),
+  carrierId: z.string().optional(),
   title: z.string(),
   origin: z.string(),
   destination: z.string(),
@@ -97,5 +98,15 @@ export async function update(id: string, input: UpdateLoadInput): Promise<Load> 
     method: "PATCH",
     body: JSON.stringify(input),
   });
+  return LoadSchema.parse(data);
+}
+
+export async function confirmPickup(id: string): Promise<Load> {
+  const data = await apiFetch<unknown>(`api/loads/${id}/confirm-pickup`, { method: "POST" });
+  return LoadSchema.parse(data);
+}
+
+export async function confirmDelivery(id: string): Promise<Load> {
+  const data = await apiFetch<unknown>(`api/loads/${id}/confirm-delivery`, { method: "POST" });
   return LoadSchema.parse(data);
 }

--- a/services/load-service/src/controllers/load.controller.ts
+++ b/services/load-service/src/controllers/load.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response, NextFunction } from 'express';
+﻿import { Request, Response, NextFunction } from 'express';
 import { loadService } from '../services/load.service';
 import { AuthRequest } from '../types';
 
@@ -62,6 +62,28 @@ export class LoadController {
       const filters = req.query as { origin?: string; destination?: string; cargoType?: string };
       const loads = await loadService.getAvailableLoads(filters);
       res.status(200).json(loads);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async confirmPickup(req: AuthRequest & { params: { id: string } }, res: Response, next: NextFunction): Promise<void> {
+    try {
+      if (!req.user) throw new Error('Unauthorized');
+
+      const load = await loadService.confirmPickup(req.params.id, req.user.userId);
+      res.status(200).json(load);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async confirmDelivery(req: AuthRequest & { params: { id: string } }, res: Response, next: NextFunction): Promise<void> {
+    try {
+      if (!req.user) throw new Error('Unauthorized');
+
+      const load = await loadService.confirmDelivery(req.params.id, req.user.userId);
+      res.status(200).json(load);
     } catch (error) {
       next(error);
     }

--- a/services/load-service/src/kafka/consumer.ts
+++ b/services/load-service/src/kafka/consumer.ts
@@ -1,4 +1,4 @@
-import { Kafka, Consumer, EachMessagePayload } from 'kafkajs';
+﻿import { Kafka, Consumer, EachMessagePayload } from 'kafkajs';
 import { KAFKA_TOPICS } from '@freightmatch/contracts';
 import { env } from '../config/env';
 import { loadService } from '../services/load.service';
@@ -28,8 +28,8 @@ export async function startConsumer(): Promise<void> {
         const event = JSON.parse(message.value.toString());
         console.log('Received bid.accepted event:', JSON.stringify(event));
 
-        await loadService.transitionStatus(event.loadId, 'InTransit');
-        console.log(`Load ${event.loadId} transitioned to InTransit via bid.accepted`);
+        await loadService.matchLoad(event.loadId, event.carrierId);
+        console.log(`Load ${event.loadId} matched to carrier ${event.carrierId} via bid.accepted`);
       } catch (error) {
         console.error('Error processing bid.accepted event:', error);
       }

--- a/services/load-service/src/models/load.model.ts
+++ b/services/load-service/src/models/load.model.ts
@@ -1,4 +1,4 @@
-import mongoose, { Document, Schema } from 'mongoose';
+﻿import mongoose, { Document, Schema } from 'mongoose';
 
 export type LoadStatus = 'Draft' | 'Posted' | 'Matched' | 'InTransit' | 'Delivered' | 'Cancelled';
 
@@ -20,6 +20,7 @@ export interface IStatusHistoryEntry {
 export interface ILoad extends Document {
   _id: mongoose.Types.ObjectId;
   shipperId: string;
+  carrierId?: string;
   title: string;
   origin: string;
   destination: string;
@@ -46,6 +47,10 @@ const loadSchema = new Schema<ILoad>(
     shipperId: {
       type: String,
       required: true,
+      index: true,
+    },
+    carrierId: {
+      type: String,
       index: true,
     },
     title: {

--- a/services/load-service/src/repositories/load.repository.ts
+++ b/services/load-service/src/repositories/load.repository.ts
@@ -1,4 +1,4 @@
-import mongoose from 'mongoose';
+﻿import mongoose from 'mongoose';
 import { Load, ILoad, LoadStatus } from '../models/load.model';
 
 export class LoadRepository {
@@ -32,6 +32,24 @@ export class LoadRepository {
           statusHistory: {
             from: fromStatus,
             to: toStatus,
+            timestamp: new Date(),
+          },
+        },
+      },
+      { new: true },
+    );
+  }
+
+  async matchWithCarrier(id: string, fromStatus: LoadStatus, carrierId: string): Promise<ILoad | null> {
+    return Load.findByIdAndUpdate(
+      id,
+      {
+        status: 'Matched',
+        carrierId,
+        $push: {
+          statusHistory: {
+            from: fromStatus,
+            to: 'Matched',
             timestamp: new Date(),
           },
         },

--- a/services/load-service/src/routes/load.routes.ts
+++ b/services/load-service/src/routes/load.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+﻿import { Router } from 'express';
 import { loadController } from '../controllers/load.controller';
 import { authenticate, authorize, authenticateOrInternal } from '../middlewares/auth.middleware';
 import { validate } from '../middlewares/validate.middleware';
@@ -41,6 +41,20 @@ router.patch(
   authorize('Shipper'),
   validate(updateStatusSchema),
   loadController.updateStatus
+);
+
+router.post(
+  '/:id/confirm-pickup',
+  authenticate,
+  authorize('Carrier'),
+  loadController.confirmPickup
+);
+
+router.post(
+  '/:id/confirm-delivery',
+  authenticate,
+  authorize('Carrier'),
+  loadController.confirmDelivery
 );
 
 router.patch(

--- a/services/load-service/src/services/load.service.ts
+++ b/services/load-service/src/services/load.service.ts
@@ -1,4 +1,4 @@
-import { KAFKA_TOPICS } from '@freightmatch/contracts';
+﻿import { KAFKA_TOPICS } from '@freightmatch/contracts';
 import { loadRepository } from '../repositories/load.repository';
 import { ErrorCode, LoadUpdateData } from '../types';
 import { LoadStatus, VALID_TRANSITIONS } from '../models/load.model';
@@ -108,6 +108,34 @@ export class LoadService {
     const load = await this.getLoadById(id);
     this.validateTransition(load.status, newStatus);
     return loadRepository.updateStatus(id, load.status, newStatus);
+  }
+
+  async matchLoad(loadId: string, carrierId: string) {
+    const load = await this.getLoadById(loadId);
+    this.validateTransition(load.status, 'Matched');
+    return loadRepository.matchWithCarrier(loadId, load.status, carrierId);
+  }
+
+  async confirmPickup(loadId: string, carrierId: string) {
+    const load = await this.getLoadById(loadId);
+    if (load.carrierId !== carrierId) {
+      const error = new Error('Not authorized to confirm pickup for this load') as Error & { statusCode: number; errorCode: string };
+      error.statusCode = 403;
+      error.errorCode = ErrorCode.FORBIDDEN;
+      throw error;
+    }
+    return this.transitionStatus(loadId, 'InTransit');
+  }
+
+  async confirmDelivery(loadId: string, carrierId: string) {
+    const load = await this.getLoadById(loadId);
+    if (load.carrierId !== carrierId) {
+      const error = new Error('Not authorized to confirm delivery for this load') as Error & { statusCode: number; errorCode: string };
+      error.statusCode = 403;
+      error.errorCode = ErrorCode.FORBIDDEN;
+      throw error;
+    }
+    return this.transitionStatus(loadId, 'Delivered');
   }
 
   private validateTransition(currentStatus: LoadStatus, newStatus: LoadStatus): void {


### PR DESCRIPTION
## Summary

- Adds carrierId field to the Load model, stored when a bid is accepted via Kafka (matchLoad)
- New POST /api/loads/:id/confirm-pickup endpoint (Carrier only): validates caller is the matched carrier, transitions Matched to InTransit
- New POST /api/loads/:id/confirm-delivery endpoint (Carrier only): validates caller is the matched carrier, transitions InTransit to Delivered
- FE: carrier marketplace load detail page shows Confirm pickup button when bid is Accepted + load is Matched, and Confirm delivery button when load is InTransit

## Test plan

- [ ] Accept a bid on a load: load transitions to Matched, carrierId stored on the document
- [ ] Matched carrier POST confirm-pickup: 200, status === InTransit
- [ ] Different carrier POST confirm-pickup: 403
- [ ] Shipper POST confirm-pickup: 403 (wrong role)
- [ ] POST confirm-pickup on non-Matched load: 409
- [ ] Matched carrier POST confirm-delivery on InTransit load: 200, status === Delivered
- [ ] Different carrier POST confirm-delivery: 403
- [ ] FE: carrier sees Confirm pickup button when bid Accepted + load Matched
- [ ] FE: clicking Confirm pickup updates status to InTransit
- [ ] FE: carrier sees Confirm delivery button when load InTransit
- [ ] FE: clicking Confirm delivery updates status to Delivered