### PR TITLE
fix(instrumentation): use v8 heap_size_limit for memory health check

### DIFF
--- a/shared/instrumentation/src/health.ts
+++ b/shared/instrumentation/src/health.ts
@@ -1,3 +1,4 @@
+import v8 from 'v8';
 import mongoose from 'mongoose';
 
 export type HealthStatus = 'healthy' | 'unhealthy' | 'degraded';
@@ -33,15 +34,16 @@ export function createHealthCheck(serviceName: string, version: string = '1.0.0'
       message: mongoStatus === 1 ? 'Connected' : mongoStatus === 0 ? 'Disconnected' : 'Connecting',
     };
 
-    // Memory check
-    const memUsage = process.memoryUsage();
-    const memUsedMB = memUsage.heapUsed / 1024 / 1024;
-    const memTotalMB = memUsage.heapTotal / 1024 / 1024;
-    const memUsagePercent = (memUsedMB / memTotalMB) * 100;
+    // Memory check — compare heapUsed against V8's actual heap size limit,
+    // not heapTotal (currently allocated pages), which sits close to heapUsed by design.
+    const heapStats = v8.getHeapStatistics();
+    const memUsedMB = heapStats.used_heap_size / 1024 / 1024;
+    const memLimitMB = heapStats.heap_size_limit / 1024 / 1024;
+    const memUsagePercent = (memUsedMB / memLimitMB) * 100;
 
     checks.memory = {
       status: memUsagePercent > 90 ? 'unhealthy' : memUsagePercent > 70 ? 'degraded' : 'healthy',
-      message: `${memUsedMB.toFixed(0)}MB / ${memTotalMB.toFixed(0)}MB`,
+      message: `${memUsedMB.toFixed(0)}MB / ${memLimitMB.toFixed(0)}MB`,
     };
 
     const overallStatus = determineOverallStatus(checks);


### PR DESCRIPTION
## Summary

All four services were reporting `unhealthy` memory despite being completely fine (e.g. `35MB / 36MB`).

**Root cause:** the check divided `heapUsed` by `heapTotal` (V8's currently *allocated* heap pages). V8 keeps `heapTotal` just slightly above `heapUsed` as a normal allocation strategy, so the ratio is almost always >90% — triggering `unhealthy` even on a fresh, idle service.

**Fix:** divide `heapUsed` by `heap_size_limit` from `v8.getHeapStatistics()`, which is the actual ceiling V8 will grow to before the process OOMs. On a 64-bit container this is typically ~1.5 GB (or whatever `--max-old-space-size` sets), so a 40 MB service correctly shows ~3% usage.

## Test plan

- [ ] Deploy and hit `/health` on any service — memory status should be `healthy`
- [ ] Memory message now shows `heapUsed / heap_size_limit` (e.g. `40MB / 1500MB`)
- [ ] `/status` page shows "All Systems Operational" when MongoDB is connected
- [ ] Thresholds still fire correctly: artificially fill heap past 70% → `degraded`; past 90% → `unhealthy`