### PR TITLE
fix: show shipper photos and return 404 to dashboard

### DIFF
--- a/apps/web/app/(carrier)/marketplace/[id]/page.tsx
+++ b/apps/web/app/(carrier)/marketplace/[id]/page.tsx
@@ -37,6 +37,7 @@ import * as bidsApi from "@/lib/api/bids";
 import type { Bid, CreateBidInput } from "@/lib/api/bids";
 import * as loadsApi from "@/lib/api/loads";
 import type { Load } from "@/lib/api/loads";
+import { resolveUploadedPhotoUrl } from "@/lib/api/uploads";
 import { getProfile, getUserById, type ProfileResponse } from "@/lib/api/users";
 
 const MIN_PRICE = 1;
@@ -375,9 +376,7 @@ function ShipperPanel({
     <section className="fm-panel-muted rounded-lg p-4">
       <SectionHeader label="Shipper" />
       <div className="mt-4 flex items-center gap-3">
-        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-slate-700 bg-slate-950 font-mono text-sm font-semibold text-amber-300">
-          {(display[0] ?? "S").toUpperCase()}
-        </div>
+        <ShipperAvatar name={display} photoUrl={shipper?.shipperProfile?.profilePhotoUrl} />
         <div className="min-w-0 flex-1">
           <p className="truncate text-sm font-semibold text-slate-100">{display}</p>
           <p className="truncate font-mono text-[11px] text-slate-500">
@@ -392,6 +391,29 @@ function ShipperPanel({
         ) : null}
       </div>
     </section>
+  );
+}
+
+function ShipperAvatar({ name, photoUrl }: { name: string; photoUrl: string | null | undefined }) {
+  const resolvedPhotoUrl = resolveUploadedPhotoUrl(photoUrl);
+  if (resolvedPhotoUrl) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={resolvedPhotoUrl}
+        alt={name}
+        className="h-10 w-10 shrink-0 rounded-md border border-slate-700 object-cover"
+      />
+    );
+  }
+
+  return (
+    <div
+      aria-hidden="true"
+      className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-slate-700 bg-slate-950 font-mono text-sm font-semibold text-amber-300"
+    >
+      {(name[0] ?? "S").toUpperCase()}
+    </div>
   );
 }
 

--- a/apps/web/app/(carrier)/marketplace/page.tsx
+++ b/apps/web/app/(carrier)/marketplace/page.tsx
@@ -39,6 +39,7 @@ import {
 import { StatusPill } from "@/components/primitives/StatusPill";
 import * as loadsApi from "@/lib/api/loads";
 import type { Load } from "@/lib/api/loads";
+import { resolveUploadedPhotoUrl } from "@/lib/api/uploads";
 import { getProfile, getUserById, type ProfileResponse } from "@/lib/api/users";
 
 const CARGO_TYPES = ["General", "Refrigerated", "Hazmat", "Oversized", "Liquid"] as const;
@@ -438,13 +439,16 @@ function LoadCard({ load, shipper }: { load: Load; shipper?: ProfileResponse }) 
         </div>
       </div>
 
-      <div className="mt-3 flex items-center justify-between text-[11px]">
-        <span className="truncate font-mono text-slate-400">
-          <span className="text-slate-500">shipper · </span>
-          <span className="text-slate-200">{shipperName}</span>
+      <div className="mt-3 flex items-center justify-between gap-2 text-[11px]">
+        <span className="flex min-w-0 items-center gap-2">
+          <ShipperAvatar name={shipperName} photoUrl={shipper?.shipperProfile?.profilePhotoUrl} />
+          <span className="truncate font-mono text-slate-400">
+            <span className="text-slate-500">shipper · </span>
+            <span className="text-slate-200">{shipperName}</span>
+          </span>
         </span>
         <ArrowRight
-          className="h-3.5 w-3.5 text-slate-500 transition-transform group-hover:translate-x-0.5 group-hover:text-amber-400"
+          className="h-3.5 w-3.5 shrink-0 text-slate-500 transition-transform group-hover:translate-x-0.5 group-hover:text-amber-400"
           aria-hidden="true"
         />
       </div>
@@ -513,6 +517,10 @@ function PinDrawer({ load, shipper }: { load: Load; shipper?: ProfileResponse })
           label="Shipper"
           value={
             <span className="inline-flex items-center gap-1.5">
+              <ShipperAvatar
+                name={shipperName}
+                photoUrl={shipper?.shipperProfile?.profilePhotoUrl}
+              />
               <span className="truncate">{shipperName}</span>
               {completed !== undefined ? (
                 <span className="inline-flex items-center gap-0.5 font-mono text-[11px] text-slate-400">
@@ -537,6 +545,29 @@ function PinDrawer({ load, shipper }: { load: Load; shipper?: ProfileResponse })
         </Button>
       </DrawerFooter>
     </>
+  );
+}
+
+function ShipperAvatar({ name, photoUrl }: { name: string; photoUrl: string | null | undefined }) {
+  const resolvedPhotoUrl = resolveUploadedPhotoUrl(photoUrl);
+  if (resolvedPhotoUrl) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={resolvedPhotoUrl}
+        alt={name}
+        className="h-6 w-6 shrink-0 rounded-full border border-slate-700 object-cover"
+      />
+    );
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-slate-700 bg-slate-950 font-mono text-[10px] font-semibold text-amber-300"
+    >
+      {(name[0] ?? "S").toUpperCase()}
+    </span>
   );
 }
 

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -31,9 +31,9 @@ export default function NotFound() {
       </p>
       <Link
         className="fm-focus-ring mt-8 inline-flex items-center gap-2 rounded-md border border-amber-400 bg-amber-400 px-4 py-2.5 font-mono text-[11px] font-semibold tracking-[0.24em] text-slate-950 uppercase shadow-[0_0_24px_rgba(245,179,66,0.18)] transition-colors hover:border-amber-500 hover:bg-amber-500"
-        href="/"
+        href="/dashboard"
       >
-        Return to base
+        Return to dashboard
       </Link>
     </main>
   );


### PR DESCRIPTION
## Summary
- Show uploaded shipper profile photos in carrier marketplace shipper info
- Send the 404 return action through /dashboard so authenticated users land on their role dashboard

## Validation
- pnpm --filter web typecheck