### PR TITLE
feat: delivery stats pipeline via load.delivered event

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,9 @@ importers:
 
   services/user-service:
     dependencies:
+      '@freightmatch/contracts':
+        specifier: workspace:*
+        version: link:../../shared/contracts
       '@freightmatch/instrumentation':
         specifier: workspace:*
         version: link:../../shared/instrumentation
@@ -330,6 +333,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.3
+      kafkajs:
+        specifier: ^2.2.4
+        version: 2.2.4
       mongoose:
         specifier: ^8.0.0
         version: 8.23.0(snappy@7.3.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))

--- a/services/load-service/src/services/load.service.ts
+++ b/services/load-service/src/services/load.service.ts
@@ -1,4 +1,4 @@
-﻿import { KAFKA_TOPICS } from '@freightmatch/contracts';
+import { KAFKA_TOPICS } from '@freightmatch/contracts';
 import { loadRepository } from '../repositories/load.repository';
 import { ErrorCode, LoadUpdateData } from '../types';
 import { LoadStatus, VALID_TRANSITIONS } from '../models/load.model';
@@ -135,7 +135,31 @@ export class LoadService {
       error.errorCode = ErrorCode.FORBIDDEN;
       throw error;
     }
-    return this.transitionStatus(loadId, 'Delivered');
+
+    this.validateTransition(load.status, 'Delivered');
+
+    const postedEntry = load.statusHistory.find((h) => h.to === 'Posted');
+    const postedAt = postedEntry ? new Date(postedEntry.timestamp) : load.createdAt;
+    const onTime = Date.now() - postedAt.getTime() <= load.deadlineHours * 3_600_000;
+
+    const inTransitEntry = load.statusHistory.find((h) => h.to === 'InTransit');
+    const inTransitAt = inTransitEntry ? new Date(inTransitEntry.timestamp) : null;
+    const actualHours = inTransitAt
+      ? Math.round(((Date.now() - inTransitAt.getTime()) / 3_600_000) * 10) / 10
+      : load.deadlineHours;
+
+    const updated = await loadRepository.updateStatus(loadId, load.status, 'Delivered');
+
+    await publishEvent(KAFKA_TOPICS.LOAD_DELIVERED, {
+      eventType: KAFKA_TOPICS.LOAD_DELIVERED,
+      loadId,
+      carrierId,
+      onTime,
+      actualHours,
+      timestamp: new Date().toISOString(),
+    });
+
+    return updated;
   }
 
   private validateTransition(currentStatus: LoadStatus, newStatus: LoadStatus): void {

--- a/services/user-service/Dockerfile
+++ b/services/user-service/Dockerfile
@@ -11,9 +11,12 @@ COPY shared/instrumentation/package.json shared/instrumentation/
 RUN pnpm install --frozen-lockfile --ignore-scripts
 COPY tsconfig.base.json ./
 COPY services/user-service/tsconfig.json services/user-service/
+COPY shared/contracts/tsconfig.json shared/contracts/
 COPY shared/instrumentation/tsconfig.json shared/instrumentation/
 COPY services/user-service/src services/user-service/src
+COPY shared/contracts shared/contracts
 COPY shared/instrumentation shared/instrumentation
+RUN pnpm --filter @freightmatch/contracts build
 RUN pnpm --filter @freightmatch/instrumentation build
 RUN pnpm --filter @freightmatch/user-service build
 
@@ -27,6 +30,7 @@ COPY services/bidding-service/package.json services/bidding-service/
 COPY services/matching-service/package.json services/matching-service/
 COPY shared/contracts/package.json shared/contracts/
 COPY shared/instrumentation/package.json shared/instrumentation/
+COPY --from=builder /app/shared/contracts/dist shared/contracts/dist
 COPY --from=builder /app/shared/instrumentation/dist shared/instrumentation/dist
 RUN pnpm install --frozen-lockfile --prod --ignore-scripts
 WORKDIR /app/services/user-service

--- a/services/user-service/package.json
+++ b/services/user-service/package.json
@@ -11,7 +11,9 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
+    "@freightmatch/contracts": "workspace:*",
     "@freightmatch/instrumentation": "workspace:*",
+    "kafkajs": "^2.2.4",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.6",
     "dotenv": "^16.3.1",

--- a/services/user-service/src/config/env.ts
+++ b/services/user-service/src/config/env.ts
@@ -10,6 +10,7 @@ const envSchema = z.object({
   JWT_REFRESH_SECRET: z.string().min(32, 'JWT_REFRESH_SECRET must be at least 32 characters for security'),
   CORS_ORIGIN: z.string().optional(),
   INTERNAL_SERVICE_SECRET: z.string().min(16, 'INTERNAL_SERVICE_SECRET must be at least 16 characters').optional(),
+  KAFKA_BROKER: z.string().default('localhost:29092'),
 });
 
 const parsed = envSchema.safeParse(process.env);

--- a/services/user-service/src/index.ts
+++ b/services/user-service/src/index.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import helmet from 'helmet';
 import cors from 'cors';
 import { connectDB, isDBConnected } from './config/db';
+import { startConsumer, disconnectConsumer } from './kafka/consumer';
 import authRoutes from './routes/auth.routes';
 import userRoutes from './routes/user.routes';
 import carrierRoutes from './routes/carrier.routes';
@@ -90,7 +91,16 @@ app.use((err: Error & { statusCode?: number; errorCode?: string }, _req: Request
 
 connectDB().then(() => {
   logger.info('user-service connected to MongoDB');
+  startConsumer().catch((err) => logger.error('Failed to start Kafka consumer', { error: err }));
   app.listen(Number(env.PORT), () => {
     logger.info(`user-service running on port ${env.PORT}`);
   });
 });
+
+async function shutdown() {
+  logger.info('user-service shutting down');
+  await disconnectConsumer();
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/services/user-service/src/kafka/consumer.ts
+++ b/services/user-service/src/kafka/consumer.ts
@@ -1,0 +1,46 @@
+import { Kafka, Consumer, EachMessagePayload } from 'kafkajs';
+import { KAFKA_TOPICS } from '@freightmatch/contracts';
+import { env } from '../config/env';
+import { userService } from '../services/user.service';
+
+const kafka = new Kafka({
+  clientId: 'user-service',
+  brokers: [env.KAFKA_BROKER],
+  retry: {
+    initialRetryTime: 300,
+    retries: 5,
+  },
+});
+
+let consumer: Consumer;
+
+export async function startConsumer(): Promise<void> {
+  consumer = kafka.consumer({ groupId: 'user-service-group' });
+  await consumer.connect();
+
+  await consumer.subscribe({ topic: KAFKA_TOPICS.LOAD_DELIVERED, fromBeginning: false });
+
+  await consumer.run({
+    eachMessage: async ({ topic, message }: EachMessagePayload) => {
+      if (topic !== KAFKA_TOPICS.LOAD_DELIVERED || !message.value) return;
+
+      try {
+        const event = JSON.parse(message.value.toString());
+        console.log(`Received ${KAFKA_TOPICS.LOAD_DELIVERED} event for load ${event.loadId}`);
+
+        await userService.recordDelivery(event.carrierId, event.onTime, event.actualHours);
+      } catch (error) {
+        console.error('Error processing load.delivered event:', error);
+      }
+    },
+  });
+
+  console.log(`Kafka consumer started, listening for ${KAFKA_TOPICS.LOAD_DELIVERED}`);
+}
+
+export async function disconnectConsumer(): Promise<void> {
+  if (consumer) {
+    await consumer.disconnect();
+    console.log('Kafka consumer disconnected');
+  }
+}

--- a/services/user-service/src/models/user.model.ts
+++ b/services/user-service/src/models/user.model.ts
@@ -8,6 +8,7 @@ export interface ICarrierProfile {
   homeCity: string;
   rating: number;
   completedShipments: number;
+  onTimeDeliveries: number;
   profilePhotoUrl: string | null;
   avgEtaHours: number;
   trustScore: number;
@@ -89,6 +90,11 @@ const userSchema = new Schema<IUser>(
           max: 5,
         },
         completedShipments: {
+          type: Number,
+          default: 0,
+          min: 0,
+        },
+        onTimeDeliveries: {
           type: Number,
           default: 0,
           min: 0,

--- a/services/user-service/src/repositories/user.repository.ts
+++ b/services/user-service/src/repositories/user.repository.ts
@@ -1,4 +1,5 @@
 import { User, IUser, ICarrierProfile, IShipperProfile } from '../models/user.model';
+import { computeTrustScore } from '../utils/trust-score.util';
 
 export class UserRepository {
   async findByEmail(email: string): Promise<IUser | null> {
@@ -64,6 +65,39 @@ export class UserRepository {
 
   async findCarrierById(id: string): Promise<IUser | null> {
     return User.findOne({ _id: id, role: 'Carrier' }).select('-passwordHash');
+  }
+
+  async recordDelivery(carrierId: string, onTime: boolean, actualHours: number): Promise<IUser | null> {
+    const doc = await User.findByIdAndUpdate(
+      carrierId,
+      {
+        $inc: {
+          'carrierProfile.completedShipments': 1,
+          'carrierProfile.onTimeDeliveries': onTime ? 1 : 0,
+        },
+      },
+      { new: true },
+    );
+
+    if (!doc || !doc.carrierProfile) return doc;
+
+    const n = doc.carrierProfile.completedShipments;
+    const newAvg = Math.round(((doc.carrierProfile.avgEtaHours * (n - 1) + actualHours) / n) * 10) / 10;
+    const onTimeRate = doc.carrierProfile.onTimeDeliveries / n;
+    const rating = Math.round(onTimeRate * 5 * 10) / 10;
+    const trustScore = computeTrustScore({ rating, onTimeRate, completedCount: n });
+
+    return User.findByIdAndUpdate(
+      carrierId,
+      {
+        $set: {
+          'carrierProfile.avgEtaHours': newAvg,
+          'carrierProfile.rating': rating,
+          'carrierProfile.trustScore': trustScore,
+        },
+      },
+      { new: true },
+    );
   }
 
   async updateLoginAttempts(

--- a/services/user-service/src/services/user.service.ts
+++ b/services/user-service/src/services/user.service.ts
@@ -79,6 +79,13 @@ export class UserService {
     return this.toCarrierResponse(carrier);
   }
 
+  async recordDelivery(carrierId: string, onTime: boolean, actualHours: number) {
+    const result = await userRepository.recordDelivery(carrierId, onTime, actualHours);
+    if (!result) {
+      console.log(`recordDelivery: carrier ${carrierId} not found, skipping`);
+    }
+  }
+
   private toCarrierResponse(user: IUser): CarrierResponse {
     return {
       id: user._id.toString(),

--- a/shared/contracts/kafka-topics.ts
+++ b/shared/contracts/kafka-topics.ts
@@ -1,6 +1,7 @@
 export const KAFKA_TOPICS = {
   LOAD_CREATED: 'load.created',
   BID_ACCEPTED: 'bid.accepted',
+  LOAD_DELIVERED: 'load.delivered',
 } as const;
 
 export type KafkaTopic = typeof KAFKA_TOPICS[keyof typeof KAFKA_TOPICS];


### PR DESCRIPTION
## Summary

- Adds `LOAD_DELIVERED` Kafka topic to shared contracts
- `confirmDelivery` now publishes `load.delivered` with `carrierId`, `onTime` flag, and `actualHours` (calculated from statusHistory timestamps)
- New Kafka consumer in user-service subscribes to `load.delivered` and updates carrier profile stats atomically:
  - `completedShipments++`
  - `onTimeDeliveries++` (if delivery was within deadline)
  - `avgEtaHours` recalculated as weighted average
  - `rating` = (onTimeDeliveries / completedShipments) x 5
  - `trustScore` recomputed via existing formula
- Adds `KAFKA_BROKER` env var to user-service config

## Test plan

- [ ] Confirm delivery as matched carrier → load transitions to Delivered
- [ ] user-service receives load.delivered event → carrier completedShipments increments
- [ ] On-time delivery (within deadlineHours) → onTimeDeliveries increments, rating approaches 5
- [ ] Late delivery → onTimeDeliveries unchanged, rating lower
- [ ] avgEtaHours updates as weighted average of actual pickup-to-delivery durations
- [ ] trustScore recalculated and visible on carrier profile page