### PR TITLE
fix(web): hide avg ETA until carrier has completed a delivery

### DIFF
--- a/apps/web/app/(carrier)/carrier/dashboard/page.tsx
+++ b/apps/web/app/(carrier)/carrier/dashboard/page.tsx
@@ -119,6 +119,7 @@ export default function CarrierDashboardPage() {
   const winRate =
     recentBids.length > 0 ? Math.round((recentAcceptedBids / recentBids.length) * 100) : 0;
   const avgEtaHours = carrierProfile?.avgEtaHours ?? 0;
+  const hasAvgEta = (carrierProfile?.completedShipments ?? 0) > 0;
   const trustScore = clampScore(carrierProfile?.trustScore ?? 0);
   const profileLoaded = profileQuery.isSuccess || profileQuery.isError;
   const isProfileIncomplete =
@@ -153,7 +154,12 @@ export default function CarrierDashboardPage() {
       <section className="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
         <KpiTile label="Open bids" value={pendingBids} />
         <KpiTile label="Win rate" value={winRate} unit="%" />
-        <KpiTile label="Avg ETA" value={avgEtaHours} maximumFractionDigits={1} unit="h" />
+        <KpiTile
+          label="Avg ETA"
+          value={hasAvgEta ? avgEtaHours : null}
+          maximumFractionDigits={1}
+          unit="h"
+        />
         <TrustScoreTile value={trustScore} />
       </section>
 

--- a/apps/web/app/(carrier)/carrier/profile/page.tsx
+++ b/apps/web/app/(carrier)/carrier/profile/page.tsx
@@ -642,7 +642,7 @@ function StatsPanel({ profile }: { profile: CarrierProfile | null }) {
         />
         <StatBar
           label="Avg ETA"
-          value={profile?.avgEtaHours ?? 0}
+          value={(profile?.completedShipments ?? 0) > 0 ? (profile?.avgEtaHours ?? 0) : null}
           max={48}
           unit="h"
           maximumFractionDigits={1}
@@ -709,7 +709,11 @@ function ShipperPreviewCard({
 
         <div className="mt-4 grid grid-cols-3 gap-2">
           <PreviewMetric label="Capacity" value={profile.capacityKg ?? 0} unit="kg" />
-          <PreviewMetric label="Avg ETA" value={profile.avgEtaHours ?? 0} unit="h" />
+          <PreviewMetric
+            label="Avg ETA"
+            value={(profile.completedShipments ?? 0) > 0 ? (profile.avgEtaHours ?? 0) : null}
+            unit="h"
+          />
           <PreviewMetric label="Done" value={profile.completedShipments ?? 0} />
         </div>
 
@@ -798,19 +802,23 @@ function StatBar({
   maximumFractionDigits?: number;
   tone: string;
   unit?: string;
-  value: number;
+  value: number | null;
 }) {
-  const pct = max > 0 ? Math.round((clamp(value, 0, max) / max) * 100) : 0;
+  const pct = value === null ? 0 : max > 0 ? Math.round((clamp(value, 0, max) / max) * 100) : 0;
   return (
     <div>
       <div className="flex items-end justify-between gap-3">
         <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-slate-500">{label}</p>
-        <MonoNum
-          value={value}
-          unit={unit}
-          maximumFractionDigits={maximumFractionDigits}
-          className="text-sm text-slate-100"
-        />
+        {value === null ? (
+          <span className="font-mono tracking-[0.02em] tabular-nums text-sm text-slate-100">—</span>
+        ) : (
+          <MonoNum
+            value={value}
+            unit={unit}
+            maximumFractionDigits={maximumFractionDigits}
+            className="text-sm text-slate-100"
+          />
+        )}
       </div>
       <div
         role="progressbar"
@@ -826,11 +834,23 @@ function StatBar({
   );
 }
 
-function PreviewMetric({ label, unit, value }: { label: string; unit?: string; value: number }) {
+function PreviewMetric({
+  label,
+  unit,
+  value,
+}: {
+  label: string;
+  unit?: string;
+  value: number | null;
+}) {
   return (
     <div className="rounded border border-slate-800 bg-slate-950/40 px-2.5 py-2">
       <p className="font-mono text-[9px] uppercase tracking-[0.18em] text-slate-500">{label}</p>
-      <MonoNum value={value} unit={unit} maximumFractionDigits={unit === "h" ? 1 : 0} />
+      {value === null ? (
+        <span className="font-mono tracking-[0.02em] tabular-nums">—</span>
+      ) : (
+        <MonoNum value={value} unit={unit} maximumFractionDigits={unit === "h" ? 1 : 0} />
+      )}
     </div>
   );
 }

--- a/apps/web/app/(shipper)/shipper/loads/[id]/page.tsx
+++ b/apps/web/app/(shipper)/shipper/loads/[id]/page.tsx
@@ -565,7 +565,8 @@ function BidCard({
   const displayName = carrier?.email?.split("@")[0] ?? "Unknown carrier";
   const trustScore = carrierProfile?.trustScore;
   const rating = carrierProfile?.rating;
-  const avgEta = carrierProfile?.avgEtaHours;
+  const avgEta =
+    (carrierProfile?.completedShipments ?? 0) > 0 ? carrierProfile?.avgEtaHours : undefined;
 
   const isAccepted = bid.status === "Accepted";
   const isRejected = bid.status === "Rejected";

--- a/apps/web/components/primitives/KpiTile.tsx
+++ b/apps/web/components/primitives/KpiTile.tsx
@@ -7,7 +7,7 @@ type Trend = {
 
 type KpiTileProps = {
   label: string;
-  value: number;
+  value: number | null;
   trend?: Trend;
   currency?: string;
   maximumFractionDigits?: number;
@@ -30,15 +30,19 @@ export function KpiTile({
     <article className="rounded-lg border border-slate-800 bg-slate-900/70 p-4">
       <p className="mb-2 font-mono text-[11px] uppercase tracking-widest text-slate-400">{label}</p>
       <div className="flex items-end justify-between gap-3">
-        <MonoNum
-          value={value}
-          currency={currency}
-          maximumFractionDigits={maximumFractionDigits}
-          minimumFractionDigits={minimumFractionDigits}
-          unit={unit}
-          className="text-3xl font-black text-slate-100"
-        />
-        {trend ? (
+        {value === null ? (
+          <span className="text-3xl font-black text-slate-100">—</span>
+        ) : (
+          <MonoNum
+            value={value}
+            currency={currency}
+            maximumFractionDigits={maximumFractionDigits}
+            minimumFractionDigits={minimumFractionDigits}
+            unit={unit}
+            className="text-3xl font-black text-slate-100"
+          />
+        )}
+        {value !== null && trend ? (
           <span className={`font-mono text-xs ${trendClass}`}>
             {trend.direction === "up" ? "▲" : "▼"}
             <MonoNum


### PR DESCRIPTION
## Summary
- `carrierProfile.avgEtaHours` is auto-computed by the user-service `load.delivered` Kafka consumer (commit 5ffede4). For carriers with zero completed deliveries, it stays at `0`, which the UI was rendering literally as `0h` — easily misread as "instant delivery".
- This change gates every Avg ETA render on `completedShipments > 0`. When unavailable, the carrier dashboard / profile / shipper-side bid card show an em-dash (or hide the chip entirely on the shipper bid card) instead of a misleading `0h`.
- No backend changes; the user-service route validator already strips `avgEtaHours` from carrier profile update payloads.

## Files
- `apps/web/components/primitives/KpiTile.tsx` — `value: number | null`, renders `—` when null and hides the trend chip.
- `apps/web/app/(carrier)/carrier/dashboard/page.tsx` — Avg ETA KPI tile passes `null` for new carriers.
- `apps/web/app/(carrier)/carrier/profile/page.tsx` — local `StatBar` and `PreviewMetric` helpers accept null; both Avg ETA call sites gate on completed shipments.
- `apps/web/app/(shipper)/shipper/loads/[id]/page.tsx` — `avgEta` resolves to `undefined` for new carriers so the existing `avgEta !== undefined` gate hides the chip.

## Test plan
- [ ] **Static scope**: `git diff origin/master...HEAD --name-only` returns exactly the 4 files above.
- [ ] **Lint**: `pnpm -F web lint` exits clean.
- [ ] **Typecheck**: `pnpm -F web typecheck` reports only the pre-existing `.next/types/validator.ts` error referencing `(shipper)/profile/page.js` — that error reproduces on `origin/master` and is unrelated to this change. No new TS errors.
- [ ] **No Co-Authored-By**: `git log -1 --format=%B fix/avg-eta-empty-state` does not contain `Co-Authored-By`.
- [ ] **No code comments added**: the diff introduces zero new `//` or `/*` comments.
- [ ] **KpiTile null branch**: `value === null` renders the literal text `—` with class `text-3xl font-black text-slate-100`; trend chip is hidden in that branch.
- [ ] **Dashboard gate**: `hasAvgEta = (carrierProfile?.completedShipments ?? 0) > 0` is computed and `value={hasAvgEta ? avgEtaHours : null}` is wired to the Avg ETA tile.
- [ ] **StatBar null branch**: `value: number | null`, renders the literal `—` with monospace styling, computes `pct = 0` for null.
- [ ] **PreviewMetric null branch**: `value: number | null`, renders the literal `—`.
- [ ] **Profile gates**: both `<StatBar label="Avg ETA" ...>` and `<PreviewMetric label="Avg ETA" ...>` pass `null` when `completedShipments === 0`.
- [ ] **Shipper bid card**: `avgEta` is `undefined` for `completedShipments === 0`, so the chip is hidden; for `completedShipments > 0` it renders as before.
- [ ] **No backend touched**: `git diff origin/master...HEAD -- services/` is empty.