### PR TITLE
fix(matching-service): swap retired claude-3.5-haiku for gpt-oss-120b

### DIFF
--- a/services/matching-service/src/services/chat.service.ts
+++ b/services/matching-service/src/services/chat.service.ts
@@ -2,7 +2,7 @@ import { env } from '../config/env';
 import { logger } from '@freightmatch/instrumentation';
 
 const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions';
-const MODEL = 'anthropic/claude-3.5-haiku';
+const MODEL = 'openai/gpt-oss-120b';
 
 const SYSTEM_PROMPT = `You are FreightMatch AI Assistant, an intelligent chatbot for a freight logistics platform. You help shippers and carriers with:
 

--- a/services/matching-service/src/services/claude.service.ts
+++ b/services/matching-service/src/services/claude.service.ts
@@ -2,7 +2,7 @@ import { env } from '../config/env';
 import { CarrierResponse, CarrierRecommendation, LoadCreatedEvent } from '../types';
 
 const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions';
-const MODEL = 'anthropic/claude-3.5-haiku';
+const MODEL = 'openai/gpt-oss-120b';
 
 function buildPrompt(load: LoadCreatedEvent, carriers: CarrierResponse[]): string {
   const carrierList = carriers


### PR DESCRIPTION
The Ask Ops assistant and carrier recommendations both pointed at anthropic/claude-3.5-haiku, which OpenRouter no longer serves. Upstream errors were masked by the fallback reply in chat.service.ts, so users just saw the canned "temporarily unavailable" message.

